### PR TITLE
v3.8

### DIFF
--- a/CutflowAnalysis/BkgEstimation.py
+++ b/CutflowAnalysis/BkgEstimation.py
@@ -29,7 +29,7 @@ def latex_setup(file_path):
 	else:
 		print("\\begin{tabular}{l|llll}")
 		print("\\hline")
-		print("\\textbf{Selection} & \\multicolumn{2}{l}{\\textbf{Number of Weighted Entries}} & \\multicolumn{2}{l}{\\textbf{Fraction of Weighted Entries}} \\\\ \\hline")
+		print("\\textbf{Selection} & \\multicolumn{2}{l}{\\textbf{Number of Entries}} & \\multicolumn{2}{l}{\\textbf{Fraction of Entries}} \\\\ \\hline") # Number of Weighted Entries
 		print(" & \\textbf{LLP 0} & \\textbf{LLP 1} & \\textbf{LLP 0} & \\textbf{LLP 1} \\\\ \\hline \\hline")
 
 def jetSplit_event_latex_setup(file_path):
@@ -43,7 +43,7 @@ def jetSplit_event_latex_setup(file_path):
 	else:
 		print("\\begin{tabular}{l|lll}")
 		print("\\hline")
-		print("\\textbf{Selection} & \\textbf{Number of Weighted Entries} & \\multicolumn{2}{l}{\\textbf{Fraction of Weighted Entries}} \\\\ \\hline")
+		print("\\textbf{Selection} & \\textbf{Number of Entries} & \\multicolumn{2}{l}{\\textbf{Fraction of Entries}} \\\\ \\hline")
 		print(" &  & All & Valid Jet \\\\ \\hline \\hline")
 
 def event_latex_setup(file_path):
@@ -56,7 +56,7 @@ def event_latex_setup(file_path):
 	else:
 		print("\\begin{tabular}{l|ll}")
 		print("\\hline")
-		print("\\textbf{Selection} & \\textbf{Number of Weighted Entries} & \\textbf{Fraction of Weighted Entries} \\\\ \\hline \\hline")
+		print("\\textbf{Selection} & \\textbf{Number of Entries} & \\textbf{Fraction of Entries} \\\\ \\hline \\hline")
 
 def latex_end(file_path):
     print("\\hline")
@@ -71,8 +71,42 @@ def main():
 	#tree     = sys.argv[2]
 	#weight   = sys.argv[3]	
 
-	jet_energy = sys.argv[2]
-	
+	# jet_energy = sys.argv[2]
+	jet_energy = "40"
+	BDT_score = sys.argv[2] # "0.999"
+
+	one_jet_tagged_string = " ( (   jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 0 condition
+	one_jet_tagged_string += " || ( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 1 condition
+	one_jet_tagged_string += " || ( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 2 condition
+	one_jet_tagged_string += " || ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 3 condition
+	one_jet_tagged_string += " || ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 4 condition
+	one_jet_tagged_string += " || ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 5 condition
+					
+	two_jet_tagged_string = " ( ( (  jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 1 condition
+	two_jet_tagged_string += " || (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 2 condition
+	two_jet_tagged_string += " || (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 3 condition
+	two_jet_tagged_string += " || (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 4 condition
+	two_jet_tagged_string += " || (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 5 condition
+	two_jet_tagged_string += " || (( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 2 condition
+	two_jet_tagged_string += " || (( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))"
+	two_jet_tagged_string += " || (( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))"	
+	two_jet_tagged_string += " || (( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))"				
+	two_jet_tagged_string += " || (( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 3 condition
+	two_jet_tagged_string += " || (( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))"
+	two_jet_tagged_string += " || (( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))"
+	two_jet_tagged_string += " || (( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 4 condition
+	two_jet_tagged_string += " || (( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))"
+	two_jet_tagged_string += " || (( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
+
+	jet_string = "((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26) || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26)"
+	jet_string += "|| (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26) || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26))"
+
+	HLT_string = "(( HLT_HT200_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT240_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT280_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1)"
+	HLT_string += "|| ( HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT270_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet60_DisplacedTrack == 1 )"
+	HLT_string += "|| ( HLT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive == 1 || HLT_HT420_L1SingleLLPJet_DisplacedDijet60_Inclusive == 1 )"
+	HLT_string += "|| ( HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay1nsInclusive == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay2nsInclusive == 1 )"
+	HLT_string += "|| HLT_L1SingleLLPJet == 1)"
+
 	if "LLP_MC" in file_path:
 		# Cutflow table for background estimation: basic event selection
 		print(" \n")
@@ -88,9 +122,9 @@ def main():
 			"LLP 0 AND LLP 1",
 			"LLP OR, with Event HT $> 200$~GeV", 
 			"LLP AND, with Event HT $> 200$~GeV", 
-            "0 jets with BDT score $\\geq 0.99$",
-            "1 jet with BDT score $\\geq 0.99$",
-            "2 jets with BDT scores $\\geq 0.99$",
+            "0 jets with BDT score $\\geq "+BDT_score+"$",
+            "1 jet with BDT score $\\geq "+BDT_score+"$",
+            "2+ jets with BDT scores $\\geq "+BDT_score+"$",
 		]
 	
 		selection_list_abbrev = [
@@ -129,55 +163,33 @@ def main():
 				selval = tree.GetEntries()
 				selval1 = tree.GetEntries()
 				init = selval
-			else:
-				if i == 1: 
-					selection_string += "(LLP0_DecayR >= 214.2 && LLP0_DecayR < 295)"
-					selection1_string += "(LLP1_DecayR >= 214.2 && LLP1_DecayR < 295)"
-				if i == 2: 
-					selection_string += "&& abs(LLP0_Eta) <= 1.26"
-					selection1_string += "&& abs(LLP1_Eta) <= 1.26"
-				if i == 3: 
-					selection_string += "&& LLP0_E > 60"
-					selection1_string += "&& LLP1_E > 60"
+			if i == 1: 
+				selection_string += "(LLP0_DecayR >= 214.2 && LLP0_DecayR < 295)"
+				selection1_string += "(LLP1_DecayR >= 214.2 && LLP1_DecayR < 295)"
+			if i == 2: 
+				selection_string += "&& abs(LLP0_Eta) <= 1.26"
+				selection1_string += "&& abs(LLP1_Eta) <= 1.26"
+			if i == 3: 
+				selection_string += "&& LLP0_E > 60"
+				selection1_string += "&& LLP1_E > 60"
 
-				if i == 4: total_selection_string = "(" + selection_string + ") || (" + selection1_string + ")"
-				if i == 5: total_selection_string = "(" + selection_string + " && " + selection1_string + ")"
-				if i == 6: total_selection_string = "((" + selection_string + ") || (" + selection1_string + ")) && eventHT > 200"
-				if i == 7: total_selection_string = "(" + selection_string + " && " + selection1_string + ") && eventHT > 200"
+			if i == 4: total_selection_string = "(" + selection_string + ") || (" + selection1_string + ")"
+			if i == 5: total_selection_string = "(" + selection_string + " && " + selection1_string + ")"
+			if i == 6: total_selection_string = "((" + selection_string + ") || (" + selection1_string + ")) && eventHT > 200"
+			if i == 7: total_selection_string = "(" + selection_string + " && " + selection1_string + ") && eventHT > 200"
 
-				if i == 8: 
-					total_selection_string += "&& (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 0 condition
-					total_selection_string += " || ( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 1 condition
-					total_selection_string += " || ( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 2 condition
-					total_selection_string += " || ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 3 condition
-					total_selection_string += " || ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 4 condition
-					total_selection_string += " || ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 5 condition
-				if i == 9: 
-					total_selection_string += "&& ((( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 0 AND 1 condition
-					total_selection_string += " || (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 0 AND 2 condition
-					total_selection_string += " || (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 0 AND 3 condition
-					total_selection_string += " || (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 0 AND 4 condition
-					total_selection_string += " || (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 0 AND 5 condition
-					total_selection_string += " || (( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 1 AND 2 condition
-					total_selection_string += " || (( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99))"
-					total_selection_string += " || (( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99))"	
-					total_selection_string += " || (( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99))"				
-					total_selection_string += " || (( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 2 AND 3 condition
-					total_selection_string += " || (( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99))"
-					total_selection_string += " || (( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99))"
-					total_selection_string += " || (( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 3 AND 4 condition
-					total_selection_string += " || (( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99))"
-					total_selection_string += " || (( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99)))" # jet 4 AND 5 condition
+			if i == 8: total_selection_string += " && " + one_jet_tagged_string
+			if i == 9: total_selection_string += " && " + two_jet_tagged_string
 
-				selval = tree.GetEntries(selection_string)
-				selval1 = tree.GetEntries(selection1_string)
+			selval = tree.GetEntries(selection_string)
+			selval1 = tree.GetEntries(selection1_string)
 
-				if i >= 4: selval = tree.GetEntries(total_selection_string)
-				if i == 7: all_events = selval
-				if i == 8: one_plus_jets = selval
-				if i == 9: two_plus_jets = selval
+			if i >= 4: selval = tree.GetEntries(total_selection_string)
+			if i == 7: all_events = selval
+			if i == 8: one_plus_jets = selval
+			if i == 9: two_plus_jets = selval
 
-				Nevents = tree.GetEntries()
+			Nevents = tree.GetEntries()
 
 			if print_latex:
 				if i < 4: print(selname+" &", round(selval, 4), "&", round(selval1, 4), "&", round(selval/init, 4), "&", round(selval1/init, 4), "\\\\")
@@ -196,24 +208,117 @@ def main():
 
 		# Cutflow table for background estimation: basic event selection
 		print(" \n")
+		print("Signal cutflow, with truth cuts (NO HT imposed), done per event")
+		print(" \n")
+
+		selection_list = [
+			"All", 
+			"LLP $r$ in HCAL", 
+			"LLP $\\abs\\eta \\leq 1.26$", 
+			"LLP $E > 40$~GeV", 
+			"LLP 0 OR LLP 1",
+            "Jet $\\geq "+jet_energy+"$~GeV $p_T$ and $\\abs\\eta \\leq 1.26$", 
+            "0 jets with BDT score $\\geq "+BDT_score+"$",
+            "1 jet with BDT score $\\geq "+BDT_score+"$",
+            "2+ jets with BDT scores $\\geq "+BDT_score+"$",
+		]
+	
+		selection_list_abbrev = [
+			"All       ", 
+			"LLP R d1-4", 
+			"LLP eta   ", 
+			"LLP pT    ", 
+			"LLP OR    ",
+			"Jet pT and eta",
+            "No jet BDT passed",
+            "Jet BDT passed",
+            "Two jet BDT passed",
+		]
+	
+		file = ROOT.TFile.Open(file_path)
+		tree = file.Get("NoSel")
+		
+		if print_latex:
+			latex_setup(file_path)
+
+		init = -1
+		
+		for i in range(len(selection_list)):
+			selname = selection_list[i]
+			selval  = -1
+			selval1 = -1
+			Nevents = -1
+
+			if i == 0: 
+				init = tree.GetEntries()
+				selection_string = ""
+				selection1_string = ""
+			if i == 1: 
+				selection_string = "(LLP0_DecayR >= 177 && LLP0_DecayR < 295)"
+				selection1_string = "(LLP1_DecayR >= 177 && LLP1_DecayR < 295)"
+			if i == 2: 
+				selection_string += "&& abs(LLP0_Eta) <= 1.26"
+				selection1_string += "&& abs(LLP1_Eta) <= 1.26"
+			if i == 3: 
+				selection_string += "&& LLP0_E > 40"
+				selection1_string += "&& LLP1_E > 40"
+
+			selval0 = tree.GetEntries(selection_string)
+			selval1 = tree.GetEntries(selection1_string)
+
+			if i == 4: total_selection_string = "((" + selection_string + ") || (" + selection1_string + "))"
+			if i == 5: total_selection_string += " && " + jet_string
+			if i == 6: total_selection_string += " && " + one_jet_tagged_string
+			if i == 7: total_selection_string += " && " + two_jet_tagged_string
+
+			if i >= 4: selval = tree.GetEntries(total_selection_string)
+			if i == 5: all_events = selval
+			if i == 6: one_plus_jets = selval
+			if i == 7: two_plus_jets = selval
+
+			Nevents = tree.GetEntries()
+
+			if print_latex:
+				if i < 4: print(selname+" &", round(selval0, 4), "&", round(selval1, 4), "&", round(selval0/init, 4), "&", round(selval1/init, 4), "\\\\")
+				if i == 4 or i == 5: 
+					print(selname+" & \\multicolumn{2}{l}{", round(selval, 4), "}& \\multicolumn{2}{l}{", round(selval/init, 4), "} \\\\")
+					if i == 5: print("\\hline")
+				if i == 6: print(selname+" & \\multicolumn{2}{l}{", round(all_events - one_plus_jets, 4), "} & \\multicolumn{2}{l}{", round((all_events - one_plus_jets)/init, 4), "} \\\\ ") # 0 bin is all events - events with at least 1
+				if i == 7: print(selname+" & \\multicolumn{2}{l}{", round(one_plus_jets - two_plus_jets, 4), "} & \\multicolumn{2}{l}{", round((one_plus_jets - two_plus_jets)/init, 4), "} \\\\ ") # 1 bin is events with at least 1 - events with at least 2
+				if i == 8: 
+					print(selname+" & \\multicolumn{2}{l}{", round(two_plus_jets, 4), "} & \\multicolumn{2}{l}{", round(two_plus_jets/init, 4), "} \\\\ ") # 2+ bin is events with at least 2
+					latex_end(file_path)
+
+			else:
+				if (i < 4): print(selection_list_abbrev[i], "\t", Nevents, "\t", round(selval, 4), "\t", round(selval/init, 4), "LLP 1:", "\t", round(selval1, 4), "\t", round(selval1/init, 4))
+				if (i >= 4): print(selection_list_abbrev[i], "\t", Nevents, "\t", round(selval, 4), "\t", round(selval/init, 4))
+
+		# Cutflow table for background estimation: basic event selection
+		print(" \n")
 		print("Signal cutflow, without truth cuts, done per event")
 		print(" \n")
 		selection_list_noCut = [
 			"All", 
-            "Jet $\\geq "+jet_energy+"$~GeV $p_T$ (one of 3 leading)", 
-            "Jet $\\abs\\eta \\leq 1.26$", 
-            "0 jets with BDT score $\\geq 0.99$",
-            "1 jet with BDT score $\\geq 0.99$",
-            "2 jets with BDT scores $\\geq 0.99$",
+            "Jet $\\geq "+jet_energy+"$~GeV $p_T$ and $\\abs\\eta \\leq 1.26$", # (one of 6 leading)", 
+            "0 jets with BDT score $\\geq "+BDT_score+"$",
+            "1 jet with BDT score $\\geq "+BDT_score+"$",
+            "2+ jets with BDT scores $\\geq "+BDT_score+"$",
+			"LLP HLT passed",
+            "HLT and 0 jets with BDT score $\\geq "+BDT_score+"$",
+            "HLT and 1 jet with BDT score $\\geq "+BDT_score+"$",
+            "HLT and 2+ jets with BDT scores $\\geq "+BDT_score+"$",
 		]
 	
 		selection_list_abbrev_noCut = [
 			"All       ",
-            "Jet pT", 
-            "Jet eta",
+            "Jet pT and eta", 
             "No jet BDT passed",
             "Jet BDT passed",
             "Two jet BDT passed",
+			"HLT passed",
+			"HLT and No jet BDT passed",
+            "HLT and Jet BDT passed",
+            "HLT and Two jet BDT passed",
 		]
 		
 		if print_latex:
@@ -227,51 +332,28 @@ def main():
 			Nevents = -1
 
 			if i == 0: 
-				selval = tree.GetEntries()
-				init = selval
-			else:
-				if i == 1: total_selection_string = "(jet0_Pt >= "+jet_energy+" || jet1_Pt >= "+jet_energy+" || jet2_Pt >= "+jet_energy+")"
-				if i == 2: total_selection_string += "&& ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26) || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26))"
-				if i == 3: 
-					total_selection_string += "&& (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 0 condition
-					total_selection_string += " || ( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 1 condition
-					total_selection_string += " || ( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 2 condition
-					total_selection_string += " || ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 3 condition
-					total_selection_string += " || ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 4 condition
-					total_selection_string += " || ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 5 condition
-				if i == 4: 
-					total_selection_string += "&& ((( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 0 AND 1 condition
-					total_selection_string += " || (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 0 AND 2 condition
-					total_selection_string += " || (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 0 AND 3 condition
-					total_selection_string += " || (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 0 AND 4 condition
-					total_selection_string += " || (( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 0 AND 5 condition
-					total_selection_string += " || (( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 1 AND 2 condition
-					total_selection_string += " || (( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99))"
-					total_selection_string += " || (( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99))"	
-					total_selection_string += " || (( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99))"				
-					total_selection_string += " || (( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 2 AND 3 condition
-					total_selection_string += " || (( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99))"
-					total_selection_string += " || (( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99))"
-					total_selection_string += " || (( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 3 AND 4 condition
-					total_selection_string += " || (( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99))"
-					total_selection_string += " || (( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99) && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99)))" # jet 4 AND 5 condition
+				init = tree.GetEntries()
+				total_selection_string = ""
+			if i == 1 or i == 5: total_selection_string = jet_string
+			if i == 2 or i == 6: total_selection_string = one_jet_tagged_string
+			if i == 3 or i == 7: total_selection_string = two_jet_tagged_string
+			if i >= 5: total_selection_string += " && " + HLT_string
 
-				selval = tree.GetEntries(total_selection_string)
-				if i == 2: all_events = selval # but end up doing comparison (denominator) to all LLP events...
-				if i == 3: one_plus_jets = selval
-				if i == 4: two_plus_jets = selval
+			selval = tree.GetEntries(total_selection_string)
+			if i == 1 or i == 5: all_events = selval # but end up doing comparison (denominator) to all LLP events...
+			if i == 2 or i == 6: one_plus_jets = selval
+			if i == 3 or i == 7: two_plus_jets = selval
 
-				Nevents = tree.GetEntries()
+			Nevents = tree.GetEntries()
 
 			if print_latex:
-				if i <= 2: 
+				if i <= 1 or i == 5: 
 					print(selname+" &", round(selval, 4), " &", round(selval/init, 4), " \\\\ ")
 					if i == 0: print("\\hline")
-				if i == 3: print(selname+" & ", round(all_events - one_plus_jets, 4), " &", round((all_events - one_plus_jets)/init, 4), " \\\\ ") # 0 bin is all events - events with at least 1
-				if i == 4: print(selname+" & ", round(one_plus_jets - two_plus_jets, 4), " &", round((one_plus_jets - two_plus_jets)/init, 4), " \\\\ ") # 1 bin is events with at least 1 - events with at least 2
-				if i == 5: 
-					print(selname+" & ", round(two_plus_jets, 4), " & ", round(two_plus_jets/init, 4), " \\\\ ") # 2+ bin is events with at least 2
-					latex_end(file_path)
+				if i == 2 or i == 6: print(selname+" & ", round(all_events - one_plus_jets, 4), " &", round((all_events - one_plus_jets)/init, 4), " \\\\ ") # 0 bin is all events - events with at least 1
+				if i == 3 or i == 7: print(selname+" & ", round(one_plus_jets - two_plus_jets, 4), " &", round((one_plus_jets - two_plus_jets)/init, 4), " \\\\ ") # 1 bin is events with at least 1 - events with at least 2
+				if i == 4 or i == 8: print(selname+" & ", round(two_plus_jets, 4), " & ", round(two_plus_jets/init, 4), " \\\\ ") # 2+ bin is events with at least 2
+				if i == 8: latex_end(file_path)
 
 			else:
 				print(selection_list_abbrev_noCut[i], "\t", Nevents, "\t", round(selval, 4), "\t", round(selval/init, 4))
@@ -282,22 +364,24 @@ def main():
 		print(" \n")
 		selection_list_noCut = [
 			"All", 
-            "Jet $\\geq "+jet_energy+"$~GeV $p_T$ (one of 6 valid)", 
-            "Jet $\\abs\\eta \\leq 1.26$", 
-			"Event HT > 200 GeV",
-            "0 jets with BDT score $\\geq 0.99$",
-            "1+ jet with BDT score $\\geq 0.99$",
-			"HCAL based HLT passed",
+            "Jet $\\geq "+jet_energy+"$~GeV $p_T$ and $\\abs\\eta \\leq 1.26$", 
+			"Event HT $\\geq 200$ GeV",
+            "0 jets with BDT score $\\geq "+BDT_score+"$",
+            "1+ jet with BDT score $\\geq "+BDT_score+"$",
+			"1+ jet and HCAL based HLT passed",
+            "2+ jet with BDT score $\\geq "+BDT_score+"$",
+			"2+ jet and HCAL based HLT passed",		
 		]
 	
 		selection_list_abbrev_noCut = [
 			"All       ",
-            "Jet pT", 
-            "Jet eta",
+            "Jet pT and eta",
 			"Event HT",
             "No jet BDT passed",
             "Jet BDT passed",
-			"HLT passed",
+			"and HLT passed",
+			"2 jet BDT passed",
+			"and HLT passed",
 		]
 		
 		if print_latex:
@@ -311,46 +395,33 @@ def main():
 			Nevents = -1
 
 			if i == 0: 
-				selval = tree.GetEntries()
-				init = selval
-			else:
-				if i == 1: 
-					total_selection_string = "(jet0_Pt >= "+jet_energy+" || jet1_Pt >= "+jet_energy+" || jet2_Pt >= "+jet_energy+" || "
-					total_selection_string += "jet3_Pt >= "+jet_energy+" || jet4_Pt >= "+jet_energy+" || jet5_Pt >= "+jet_energy+")"
-				if i == 2: 
-					total_selection_string = "((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26) || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26)"
-					total_selection_string += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26) || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26))"
-				if i == 3: total_selection_string += " && eventHT > 200"
-				if i == 4: 
-					total_selection_string =  " ( (  jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 0 condition
-					total_selection_string += " || ( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 1 condition
-					total_selection_string += " || ( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 2 condition
-					total_selection_string += " || ( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 3 condition
-					total_selection_string += " || ( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= 0.99)" # jet 4 condition
-					total_selection_string += " || ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= 0.99))" # jet 5 condition
-					total_selection_string += " && eventHT > 200"
-				if i == 6: 
-					total_selection_string += "&& (( HLT_HT200_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT240_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT280_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1)"
-					total_selection_string += "|| ( HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT270_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet60_DisplacedTrack == 1 )"
-					total_selection_string += "|| ( HLT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive == 1 || HLT_HT420_L1SingleLLPJet_DisplacedDijet60_Inclusive == 1 )"
-					total_selection_string += "|| ( HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay1nsInclusive == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay2nsInclusive == 1 )"
-					total_selection_string += "|| HLT_L1SingleLLPJet == 1)"
+				init = tree.GetEntries()
+				total_selection_string = ""
+			if i == 1: total_selection_string = jet_string
+			if i == 2: total_selection_string += " && eventHT > 200"
+			if i == 3: 
+				total_selection_string += " && " + one_jet_tagged_string
+				two_selection_string = total_selection_string + " && " + two_jet_tagged_string
+			if i == 5: total_selection_string += " && " + HLT_string
+			if i == 7: total_selection_string = two_selection_string + " && " + HLT_string
 
-				selval = tree.GetEntries(total_selection_string)
-				if i == 3: all_events = selval # but end up doing comparison (denominator) to all LLP events...
-				if i == 4: one_plus_jets = selval
+			selval = tree.GetEntries(total_selection_string)
+			if i == 2: all_events = selval # but end up doing comparison (denominator) to all LLP events...
+			if i == 3: 
+				one_plus_jets = selval
+				two_plus_jets = tree.GetEntries(two_selection_string)
 
-				Nevents = tree.GetEntries()
+			Nevents = tree.GetEntries()
 
 			if print_latex:
-				if i <= 3: 
+				if i <= 2: 
 					print(selname+" &", round(selval, 4), " &", round(selval/init, 4), " \\\\ ")
 					if i == 0: print("\\hline")
-				if i == 4: print(selname+" & ", round(all_events - one_plus_jets, 4), " &", round((all_events - one_plus_jets)/init, 4), " \\\\ ") # 0 bin is all events - events with at least 1
-				if i == 5: print(selname+" & ", round(one_plus_jets, 4), " &", round((one_plus_jets)/init, 4), " \\\\ ") # 1 bin is events with at least 1 
-				if i == 6: 
-					print(selname+" & ", round(selval, 4), " & ", round(selval/init, 4), " \\\\ ") 
-					latex_end(file_path)
+				if i == 3: print(selname+" & ", round(all_events - one_plus_jets, 4), " &", round((all_events - one_plus_jets)/init, 4), " \\\\ ") # 0 bin is all events - events with at least 1
+				if i == 4: print(selname+" & ", round(one_plus_jets - two_plus_jets, 4), " &", round((one_plus_jets - two_plus_jets)/init, 4), " \\\\ ") # 1 bin is events with at least 1 
+				if i == 5 or i == 7: print(selname+" & ", round(selval, 4), " & ", round(selval/init, 4), " \\\\ ") 
+				if i == 6: print(selname+" & ", round(two_plus_jets, 4), " &", round((two_plus_jets)/init, 4), " \\\\ ")
+				if i == 7: latex_end(file_path)
 
 			else:
 				print(selection_list_abbrev_noCut[i], "\t", Nevents, "\t", round(selval, 4), "\t", round(selval/init, 4))
@@ -362,23 +433,21 @@ def main():
 		print("Background (W+jets, then NoSel) cutflow, done per event")
 		print(" \n")
 
-		BDT_score = "0.998"
-
 		event_selection_list = [
             "All events (from skim)", 
             "Jet $\\geq "+jet_energy+"$~GeV $p_T$ (one of 6 leading)", 
             "Jet $\\abs\\eta \\leq 1.26$", 
             "0 jets with BDT score $\\geq "+BDT_score+"$",
             "1 jet with BDT score $\\geq "+BDT_score+"$",
-            "2 jets with BDT scores $\\geq "+BDT_score+"$",
+            "2+ jets with BDT scores $\\geq "+BDT_score+"$",
 			"Jet $\\geq "+jet_energy+"$~GeV $p_T$, $\\abs\\eta \\leq 1.26$, triggered",
 			"0 jets with BDT score $\\geq "+BDT_score+"$",
             "1 jet with BDT score $\\geq "+BDT_score+"$",
-            "2 jets with BDT scores $\\geq "+BDT_score+"$",
+            "2+ jets with BDT scores $\\geq "+BDT_score+"$",
 			"Jet $\\geq "+jet_energy+"$~GeV $p_T$, $\\abs\\eta \\leq 1.26$, not triggered",
 			"0 jets with BDT score $\\geq "+BDT_score+"$",
             "1 jet with BDT score $\\geq "+BDT_score+"$",
-            "2 jets with BDT scores $\\geq "+BDT_score+"$",
+            "2+ jets with BDT scores $\\geq "+BDT_score+"$",
         ]
         
 		event_selection_list_abbrev = [
@@ -401,7 +470,7 @@ def main():
 		# trees = ["WPlusJets", "NoSel"]
 		trees = ["WPlusJets"]
 		for tree_sel in trees:
-			print("\n Running fo: " + tree_sel + " \n")
+			print("\n Running for: " + tree_sel + " \n")
 			file = ROOT.TFile.Open(file_path)
 			tree = file.Get(tree_sel)
 			
@@ -420,98 +489,75 @@ def main():
 				if i == 0: 
 					selval = tree.GetEntries()
 					init = selval
-				else:
-					if i == 1: 
-						selection_string = "(jet0_Pt >= "+jet_energy+" || jet1_Pt >= "+jet_energy+" || jet2_Pt >= "+jet_energy+" || jet3_Pt >= "+jet_energy+" || jet4_Pt >= "+jet_energy+" || jet5_Pt >= "+jet_energy+")"
-					if i == 2: 
-						selection_string = "((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26) || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26)"
-						selection_string += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26) || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26))"
-					if i == 3: 
-						selection_string = " ( (  jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 0 condition
-						selection_string += " || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 1 condition
-						selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 2 condition
-						selection_string += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 3 condition
-						selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 4 condition
-						selection_string += " || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 5 condition
-					if i == 4: 
-						selection_string = " ( ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 1 condition
-						selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 2 condition
-						selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 3 condition
-						selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 4 condition
-						selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 5 condition
-						selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 2 condition
-						selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 3 condition
-						selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 4 condition
-						selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 5 condition
-						selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 3 condition
-						selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 4 condition
-						selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 5 condition
-						selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 4 condition
-						selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 5 condition
-						selection_string += " || ((jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
-					# triggered jet
-					if i == 6: 
-						selection_string = "  ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1)"
-						selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1) || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1)"
-						selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1))"
-					if i == 7: 
-						selection_string = " ( (  jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 0 condition
-						selection_string += " || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 1 condition
-						selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 2 condition
-						selection_string += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 3 condition
-						selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 4 condition
-						selection_string += " || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 5 condition
-					if i == 8: 
-						selection_string = " ( ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 1 condition
-						selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 2 condition
-						selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 3 condition
-						selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 4 condition
-						selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 5 condition
-						selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 2 condition
-						selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 3 condition
-						selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 4 condition
-						selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 5 condition
-						selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 3 condition
-						selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 4 condition
-						selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 5 condition
-						selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 4 condition
-						selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 5 condition
-						selection_string += " || ((jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
-					# Non-triggered jet
-					if i == 10: 
-						selection_string = "  ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0)"
-						selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0) || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0)"
-						selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0))"
-					if i == 11: 
-						selection_string = " ( (  jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 0 condition
-						selection_string += " || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 1 condition
-						selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 2 condition
-						selection_string += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 3 condition
-						selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 4 condition
-						selection_string += " || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 5 condition
-					if i == 12: 
-						selection_string = " ( ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 1 condition
-						selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 2 condition
-						selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 3 condition
-						selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 4 condition
-						selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 5 condition
-						selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 2 condition
-						selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 3 condition
-						selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 4 condition
-						selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 5 condition
-						selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 3 condition
-						selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 4 condition
-						selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 5 condition
-						selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 4 condition
-						selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 5 condition
-						selection_string += " || ((jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
+				if i == 1: 
+					selection_string = "(jet0_Pt >= "+jet_energy+" || jet1_Pt >= "+jet_energy+" || jet2_Pt >= "+jet_energy+" || jet3_Pt >= "+jet_energy+" || jet4_Pt >= "+jet_energy+" || jet5_Pt >= "+jet_energy+")"
+				if i == 2: 
+					selection_string = "((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26) || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26)"
+					selection_string += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26) || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26))"
+				if i == 3: selection_string = one_jet_tagged_string
+				if i == 4: selection_string = two_jet_tagged_string
+				# triggered jet
+				if i == 6: 
+					selection_string = "  ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1)"
+					selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1) || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1)"
+					selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1))"
+				if i == 7: 
+					selection_string = " ( (  jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 0 condition
+					selection_string += " || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 1 condition
+					selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 2 condition
+					selection_string += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 3 condition
+					selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 4 condition
+					selection_string += " || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 5 condition
+				if i == 8: 
+					selection_string = " ( ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 1 condition
+					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 2 condition
+					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 3 condition
+					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 4 condition
+					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 5 condition
+					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 2 condition
+					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 3 condition
+					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 4 condition
+					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 5 condition
+					selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 3 condition
+					selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 4 condition
+					selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 5 condition
+					selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 4 condition
+					selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 5 condition
+					selection_string += " || ((jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
+				# Non-triggered jet
+				if i == 10: 
+					selection_string = "  ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0)"
+					selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0) || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0)"
+					selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0))"
+				if i == 11: 
+					selection_string = " ( (  jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 0 condition
+					selection_string += " || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 1 condition
+					selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 2 condition
+					selection_string += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 3 condition
+					selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 4 condition
+					selection_string += " || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 5 condition
+				if i == 12: 
+					selection_string = " ( ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 1 condition
+					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 2 condition
+					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 3 condition
+					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 4 condition
+					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 5 condition
+					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 2 condition
+					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 3 condition
+					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 4 condition
+					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 5 condition
+					selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 3 condition
+					selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 4 condition
+					selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 5 condition
+					selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 4 condition
+					selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 5 condition
+					selection_string += " || ((jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
 
-
-					selval = tree.GetEntries(selection_string)
-					if i % 4 == 2: all_events = selval # i = 2, 6, 10
-					if i % 4 == 3: one_plus_jets = selval # i = 3, 7, 11
-					if i % 4 == 0: two_plus_jets = selval # i = 4, 8, 12
-					Nevents = tree.GetEntries()
+				selval = tree.GetEntries(selection_string)
+				if i % 4 == 2: all_events = selval # i = 2, 6, 10
+				if i % 4 == 3: one_plus_jets = selval # i = 3, 7, 11
+				if i % 4 == 0: two_plus_jets = selval # i = 4, 8, 12
+				Nevents = tree.GetEntries()
 
 				if print_latex:
 					if i < 2: print(selname+" &", round(selval, 4), "&\\multicolumn{2}{l}{", round(selval/init, 4), "} \\\\ ")
@@ -568,16 +614,15 @@ def main():
 			if i == 0: 
 				selval = tree.GetEntries()
 				init = selval
-			else:
-				if i == 1: selection_string += "(jet0_Pt >= 40 || jet1_Pt >= 40 || jet2_Pt >= 40)"
-				if i == 2: selection_string += "&& ((jet0_Pt >= 40 && abs(jet0_Eta) <= 1.26) || (jet1_Pt >= 40 && abs(jet1_Eta) <= 1.26) || (jet2_Pt >= 40 && abs(jet2_Eta) <= 1.26))"
-				if i == 4: selection_string = "(jet0_Pt >= 60 || jet1_Pt >= 60 || jet2_Pt >= 60)"
-				if i == 5: selection_string += "&& ((jet0_Pt >= 60 && abs(jet0_Eta) <= 1.26) || (jet1_Pt >= 60 && abs(jet1_Eta) <= 1.26) || (jet2_Pt >= 60 && abs(jet2_Eta) <= 1.26))"
+			if i == 1: selection_string += "(jet0_Pt >= 40 || jet1_Pt >= 40 || jet2_Pt >= 40)"
+			if i == 2: selection_string += "&& ((jet0_Pt >= 40 && abs(jet0_Eta) <= 1.26) || (jet1_Pt >= 40 && abs(jet1_Eta) <= 1.26) || (jet2_Pt >= 40 && abs(jet2_Eta) <= 1.26))"
+			if i == 4: selection_string = "(jet0_Pt >= 60 || jet1_Pt >= 60 || jet2_Pt >= 60)"
+			if i == 5: selection_string += "&& ((jet0_Pt >= 60 && abs(jet0_Eta) <= 1.26) || (jet1_Pt >= 60 && abs(jet1_Eta) <= 1.26) || (jet2_Pt >= 60 && abs(jet2_Eta) <= 1.26))"
 								
-				selval = tree.GetEntries(selection_string)
-				if (i == 2 or i == 5): all_events = selval
-				if i == 3: selval = all_events * 0.0014
-				if i == 6: selval = all_events * 0.0012
+			selval = tree.GetEntries(selection_string)
+			if (i == 2 or i == 5): all_events = selval
+			if i == 3: selval = all_events * 0.0004
+			if i == 6: selval = all_events * 0.0003
 
 			if print_latex:
 				print(selname+" &", round(selval, 4), "&", round(selval/init, 4), " \\\\ ")

--- a/CutflowAnalysis/BkgEstimation.py
+++ b/CutflowAnalysis/BkgEstimation.py
@@ -322,7 +322,7 @@ def main():
 		]
 		
 		if print_latex:
-			event_latex_setup(file_path)
+			jetSplit_event_latex_setup(file_path)
 
 		init = -1
 		
@@ -340,6 +340,7 @@ def main():
 			if i >= 5: total_selection_string += " && " + HLT_string
 
 			selval = tree.GetEntries(total_selection_string)
+			if i == 1: valid_events = selval
 			if i == 1 or i == 5: all_events = selval # but end up doing comparison (denominator) to all LLP events...
 			if i == 2 or i == 6: one_plus_jets = selval
 			if i == 3 or i == 7: two_plus_jets = selval
@@ -347,12 +348,12 @@ def main():
 			Nevents = tree.GetEntries()
 
 			if print_latex:
-				if i <= 1 or i == 5: 
-					print(selname+" &", round(selval, 4), " &", round(selval/init, 4), " \\\\ ")
-					if i == 0: print("\\hline")
-				if i == 2 or i == 6: print(selname+" & ", round(all_events - one_plus_jets, 4), " &", round((all_events - one_plus_jets)/init, 4), " \\\\ ") # 0 bin is all events - events with at least 1
-				if i == 3 or i == 7: print(selname+" & ", round(one_plus_jets - two_plus_jets, 4), " &", round((one_plus_jets - two_plus_jets)/init, 4), " \\\\ ") # 1 bin is events with at least 1 - events with at least 2
-				if i == 4 or i == 8: print(selname+" & ", round(two_plus_jets, 4), " & ", round(two_plus_jets/init, 4), " \\\\ ") # 2+ bin is events with at least 2
+				if i == 0: print(selname+" &", round(selval, 4), "&\\multicolumn{2}{l}{", round(selval/init, 4), "} \\\\ ")
+				if i == 1 or i == 5: print(selname+" &", round(selval, 4), " &", round(selval/init, 4), " &", round(selval/valid_events, 4), " \\\\ ")
+				if i == 2 or i == 6: print(selname+" & ", round(all_events - one_plus_jets, 4), " &", round((all_events - one_plus_jets)/init, 4), " &", round((all_events - one_plus_jets)/valid_events, 4), " \\\\ ") # 0 bin is all events - events with at least 1
+				if i == 3 or i == 7: print(selname+" & ", round(one_plus_jets - two_plus_jets, 4), " &", round((one_plus_jets - two_plus_jets)/init, 4), " &", round((one_plus_jets - two_plus_jets)/valid_events, 4), " \\\\ ") # 1 bin is events with at least 1 - events with at least 2
+				if i == 4 or i == 8: print(selname+" & ", round(two_plus_jets, 4), " & ", round(two_plus_jets/init, 4), " & ", round(two_plus_jets/valid_events, 4), " \\\\ ") # 2+ bin is events with at least 2
+				if i == 0 or i == 4: print("\\hline")
 				if i == 8: latex_end(file_path)
 
 			else:
@@ -467,8 +468,8 @@ def main():
             "Two jet BDT passed",
         ]
 
-		# trees = ["WPlusJets", "NoSel"]
-		trees = ["WPlusJets"]
+		trees = ["WPlusJets", "NoSel"]
+		# trees = ["WPlusJets"]
 		for tree_sel in trees:
 			print("\n Running for: " + tree_sel + " \n")
 			file = ROOT.TFile.Open(file_path)
@@ -485,6 +486,10 @@ def main():
 				selname = event_selection_list[i]
 				selval  = -1
 				Nevents = -1
+
+				if tree_sel == "NoSel" and i >= 5 and i % 4 == 1: # do not unblind for data!!
+					if i == 13: latex_end(file_path)
+					continue
 
 				if i == 0: 
 					selval = tree.GetEntries()
@@ -562,7 +567,7 @@ def main():
 				if print_latex:
 					if i < 2: print(selname+" &", round(selval, 4), "&\\multicolumn{2}{l}{", round(selval/init, 4), "} \\\\ ")
 					if i % 4 == 2: print(selname+" &", round(selval, 4), "&", round(selval/init, 4), "&", round(selval/all_events, 4), " \\\\ ")
-					if i % 4 == 3: print(selname+" &", round(all_events - one_plus_jets, 4), "&", round((all_events - one_plus_jets)/init, 4),  "&", round((all_events - one_plus_jets)/all_events, 4), " \\\\ ") # 0 bin is all events - events with at least 1
+					if i % 4 == 3 and tree_sel != "NoSel": print(selname+" &", round(all_events - one_plus_jets, 4), "&", round((all_events - one_plus_jets)/init, 4),  "&", round((all_events - one_plus_jets)/all_events, 4), " \\\\ ") # 0 bin is all events - events with at least 1
 					if i > 0 and i % 4 == 0: print(selname+" &", round(one_plus_jets - two_plus_jets, 4), "&", round((one_plus_jets - two_plus_jets)/init, 4),  "&", round((one_plus_jets - two_plus_jets)/all_events, 4), " \\\\ ") # 1 bin is events with at least 1 - events with at least 2
 					if i >= 5 and i % 4 == 1: 
 						print(selname+" &", round(two_plus_jets, 4), "&", round(two_plus_jets/init, 4),  "&", round(two_plus_jets/all_events, 4), " \\\\ ") # 2+ bin is events with at least 2

--- a/CutflowAnalysis/BkgEstimation.py
+++ b/CutflowAnalysis/BkgEstimation.py
@@ -398,7 +398,7 @@ def main():
 				init = tree.GetEntries()
 				total_selection_string = ""
 			if i == 1: total_selection_string = jet_string
-			if i == 2: total_selection_string += " && eventHT > 200"
+			if i == 2: total_selection_string += " && eventHT > 200" # slight difference caused by addition of this as compared to above HLT cutflow
 			if i == 3: 
 				total_selection_string += " && " + one_jet_tagged_string
 				two_selection_string = total_selection_string + " && " + two_jet_tagged_string

--- a/CutflowAnalysis/BkgEstimation.py
+++ b/CutflowAnalysis/BkgEstimation.py
@@ -75,6 +75,9 @@ def main():
 	jet_energy = "40"
 	BDT_score = sys.argv[2] # "0.999"
 
+	jet_string = "((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26) || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26)"
+	jet_string += "|| (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26) || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26))"
+
 	one_jet_tagged_string = " ( (   jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 0 condition
 	one_jet_tagged_string += " || ( jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 1 condition
 	one_jet_tagged_string += " || ( jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 2 condition
@@ -98,8 +101,61 @@ def main():
 	two_jet_tagged_string += " || (( jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))"
 	two_jet_tagged_string += " || (( jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && ( jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
 
-	jet_string = "((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26) || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26)"
-	jet_string += "|| (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26) || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26))"
+
+	jet_string_triggered = "  ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1)"
+	jet_string_triggered += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1) || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1)"
+	jet_string_triggered += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1))"	
+
+	one_jet_tagged_string_triggered = " ( (  jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 0 condition
+	one_jet_tagged_string_triggered += " || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 1 condition
+	one_jet_tagged_string_triggered += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 2 condition
+	one_jet_tagged_string_triggered += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 3 condition
+	one_jet_tagged_string_triggered += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 4 condition
+	one_jet_tagged_string_triggered += " || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 5 condition
+
+	two_jet_tagged_string_triggered = " ( ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 1 condition
+	two_jet_tagged_string_triggered += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 2 condition
+	two_jet_tagged_string_triggered += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 3 condition
+	two_jet_tagged_string_triggered += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 4 condition
+	two_jet_tagged_string_triggered += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 5 condition
+	two_jet_tagged_string_triggered += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 2 condition
+	two_jet_tagged_string_triggered += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 3 condition
+	two_jet_tagged_string_triggered += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 4 condition
+	two_jet_tagged_string_triggered += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 5 condition
+	two_jet_tagged_string_triggered += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 3 condition
+	two_jet_tagged_string_triggered += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 4 condition
+	two_jet_tagged_string_triggered += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 5 condition
+	two_jet_tagged_string_triggered += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 4 condition
+	two_jet_tagged_string_triggered += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 5 condition
+	two_jet_tagged_string_triggered += " || ((jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
+
+
+	jet_string_not_triggered = "  ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0)"
+	jet_string_not_triggered += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0) || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0)"
+	jet_string_not_triggered += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0))"
+
+	one_jet_tagged_string_not_triggered = " ( (  jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 0 condition
+	one_jet_tagged_string_not_triggered += " || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 1 condition
+	one_jet_tagged_string_not_triggered += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 2 condition
+	one_jet_tagged_string_not_triggered += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 3 condition
+	one_jet_tagged_string_not_triggered += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 4 condition
+	one_jet_tagged_string_not_triggered += " || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 5 condition
+
+	two_jet_tagged_string_not_triggered = " ( ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 1 condition
+	two_jet_tagged_string_not_triggered += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 2 condition
+	two_jet_tagged_string_not_triggered += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 3 condition
+	two_jet_tagged_string_not_triggered += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 4 condition
+	two_jet_tagged_string_not_triggered += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 5 condition
+	two_jet_tagged_string_not_triggered += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 2 condition
+	two_jet_tagged_string_not_triggered += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 3 condition
+	two_jet_tagged_string_not_triggered += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 4 condition
+	two_jet_tagged_string_not_triggered += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 5 condition
+	two_jet_tagged_string_not_triggered += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 3 condition
+	two_jet_tagged_string_not_triggered += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 4 condition
+	two_jet_tagged_string_not_triggered += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 5 condition
+	two_jet_tagged_string_not_triggered += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 4 condition
+	two_jet_tagged_string_not_triggered += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 5 condition
+	two_jet_tagged_string_not_triggered += " || ((jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
 
 	HLT_string = "(( HLT_HT200_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT240_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT280_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1)"
 	HLT_string += "|| ( HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT270_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet60_DisplacedTrack == 1 )"
@@ -307,6 +363,16 @@ def main():
             "HLT and 0 jets with BDT score $\\geq "+BDT_score+"$",
             "HLT and 1 jet with BDT score $\\geq "+BDT_score+"$",
             "HLT and 2+ jets with BDT scores $\\geq "+BDT_score+"$",
+			"Jet $\\geq "+jet_energy+"$~GeV $p_T$, $\\abs\\eta \\leq 1.26$, triggered",
+			"LLP HLT passed",
+            "HLT and 0 jets with BDT score $\\geq "+BDT_score+"$",
+            "HLT and 1 jet with BDT score $\\geq "+BDT_score+"$",
+            "HLT and 2+ jets with BDT scores $\\geq "+BDT_score+"$",
+			"Jet $\\geq "+jet_energy+"$~GeV $p_T$, $\\abs\\eta \\leq 1.26$, not triggered",
+			"LLP HLT passed",
+            "HLT and 0 jets with BDT score $\\geq "+BDT_score+"$",
+            "HLT and 1 jet with BDT score $\\geq "+BDT_score+"$",
+            "HLT and 2+ jets with BDT scores $\\geq "+BDT_score+"$",
 		]
 	
 		selection_list_abbrev_noCut = [
@@ -315,6 +381,16 @@ def main():
             "No jet BDT passed",
             "Jet BDT passed",
             "Two jet BDT passed",
+			"HLT passed",
+			"HLT and No jet BDT passed",
+            "HLT and Jet BDT passed",
+            "HLT and Two jet BDT passed",
+			"Triggered", 
+			"HLT passed",
+			"HLT and No jet BDT passed",
+            "HLT and Jet BDT passed",
+            "HLT and Two jet BDT passed",
+			"Not triggered", 
 			"HLT passed",
 			"HLT and No jet BDT passed",
             "HLT and Jet BDT passed",
@@ -337,24 +413,35 @@ def main():
 			if i == 1 or i == 5: total_selection_string = jet_string
 			if i == 2 or i == 6: total_selection_string = one_jet_tagged_string
 			if i == 3 or i == 7: total_selection_string = two_jet_tagged_string
-			if i >= 5: total_selection_string += " && " + HLT_string
+
+			if i == 9 or i == 10: total_selection_string = jet_string_triggered
+			if i == 11: total_selection_string = one_jet_tagged_string_triggered
+			if i == 12: total_selection_string = two_jet_tagged_string_triggered
+
+			if i == 14 or i == 15: total_selection_string = jet_string_not_triggered
+			if i == 16: total_selection_string = one_jet_tagged_string_not_triggered
+			if i == 17: total_selection_string = two_jet_tagged_string_not_triggered
+
+			if i >= 5 and i != 9 and i != 14: total_selection_string += " && " + HLT_string # i == 9, 14 are for triggered / not, without HLT requirement
 
 			selval = tree.GetEntries(total_selection_string)
-			if i == 1: valid_events = selval
-			if i == 1 or i == 5: all_events = selval # but end up doing comparison (denominator) to all LLP events...
-			if i == 2 or i == 6: one_plus_jets = selval
-			if i == 3 or i == 7: two_plus_jets = selval
+			if i == 1 or i == 9 or i == 14: valid_events = selval # all valid events, triggered valid events, non-triggered valid events
+			if (i % 4 == 1 and i <= 5) or i == 10 or i == 15: all_events = selval # i == 1, 5, 9, 14 # do comparison (denominator) to all LLP events and valid events both
+			if (i % 4 == 2 and i <= 6) or i == 11 or i == 16: one_plus_jets = selval # i == 2, 6, 11, 16
+			if i == 16: print(all_events, " = all events, one plus jets = ", one_plus_jets)
+			if (i % 4 == 3 and i <= 7) or i == 12 or i == 17: two_plus_jets = selval # i == 3, 7, 12, 17
 
 			Nevents = tree.GetEntries()
 
 			if print_latex:
 				if i == 0: print(selname+" &", round(selval, 4), "&\\multicolumn{2}{l}{", round(selval/init, 4), "} \\\\ ")
-				if i == 1 or i == 5: print(selname+" &", round(selval, 4), " &", round(selval/init, 4), " &", round(selval/valid_events, 4), " \\\\ ")
-				if i == 2 or i == 6: print(selname+" & ", round(all_events - one_plus_jets, 4), " &", round((all_events - one_plus_jets)/init, 4), " &", round((all_events - one_plus_jets)/valid_events, 4), " \\\\ ") # 0 bin is all events - events with at least 1
-				if i == 3 or i == 7: print(selname+" & ", round(one_plus_jets - two_plus_jets, 4), " &", round((one_plus_jets - two_plus_jets)/init, 4), " &", round((one_plus_jets - two_plus_jets)/valid_events, 4), " \\\\ ") # 1 bin is events with at least 1 - events with at least 2
-				if i == 4 or i == 8: print(selname+" & ", round(two_plus_jets, 4), " & ", round(two_plus_jets/init, 4), " & ", round(two_plus_jets/valid_events, 4), " \\\\ ") # 2+ bin is events with at least 2
-				if i == 0 or i == 4: print("\\hline")
-				if i == 8: latex_end(file_path)
+				if (i % 4 == 1 and i <= 9) or i == 10 or i == 14 or i == 15: print(selname+" &", round(selval, 4), " &", round(selval/init, 4), " &", round(selval/valid_events, 4), " \\\\ ")
+				if (i % 4 == 2 and i <= 6) or i == 11 or i == 16: print(selname+" & ", round(all_events - one_plus_jets, 4), " &", round((all_events - one_plus_jets)/init, 4), " &", round((all_events - one_plus_jets)/valid_events, 4), " \\\\ ") # 0 bin is all events - events with at least 1
+				if (i % 4 == 3 and i <= 7) or i == 12 or i == 17: print(selname+" & ", round(one_plus_jets - two_plus_jets, 4), " &", round((one_plus_jets - two_plus_jets)/init, 4), " &", round((one_plus_jets - two_plus_jets)/valid_events, 4), " \\\\ ") # 1 bin is events with at least 1 - events with at least 2
+				if (i % 4 == 0 and i <= 8) or i == 13 or i == 18: 
+					if i >= 4: print(selname+" & ", round(two_plus_jets, 4), " & ", round(two_plus_jets/init, 4), " & ", round(two_plus_jets/valid_events, 4), " \\\\ ") # 2+ bin is events with at least 2
+					if i != 18: print("\\hline")
+					else: latex_end(file_path)
 
 			else:
 				print(selection_list_abbrev_noCut[i], "\t", Nevents, "\t", round(selval, 4), "\t", round(selval/init, 4))
@@ -436,8 +523,7 @@ def main():
 
 		event_selection_list = [
             "All events (from skim)", 
-            "Jet $\\geq "+jet_energy+"$~GeV $p_T$ (one of 6 leading)", 
-            "Jet $\\abs\\eta \\leq 1.26$", 
+			"Jet $\\geq "+jet_energy+"$~GeV $p_T$ and $\\abs\\eta \\leq 1.26$", # (one of 6 leading)", 
             "0 jets with BDT score $\\geq "+BDT_score+"$",
             "1 jet with BDT score $\\geq "+BDT_score+"$",
             "2+ jets with BDT scores $\\geq "+BDT_score+"$",
@@ -453,8 +539,7 @@ def main():
         
 		event_selection_list_abbrev = [
             "All       ", 
-            "Jet pT", 
-            "Jet eta",
+            "Jet pT and eta", 
             "No jet BDT passed",
             "Jet BDT passed",
             "Two jet BDT passed",
@@ -487,92 +572,40 @@ def main():
 				selval  = -1
 				Nevents = -1
 
-				if tree_sel == "NoSel" and i >= 5 and i % 4 == 1: # do not unblind for data!!
-					if i == 13: latex_end(file_path)
+				if tree_sel == "NoSel" and i >= 4 and i % 4 == 0: # do not unblind for data!!
+					if i == 12: latex_end(file_path)
 					continue
 
 				if i == 0: 
 					selval = tree.GetEntries()
 					init = selval
-				if i == 1: 
-					selection_string = "(jet0_Pt >= "+jet_energy+" || jet1_Pt >= "+jet_energy+" || jet2_Pt >= "+jet_energy+" || jet3_Pt >= "+jet_energy+" || jet4_Pt >= "+jet_energy+" || jet5_Pt >= "+jet_energy+")"
-				if i == 2: 
-					selection_string = "((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26) || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26)"
-					selection_string += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26) || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26))"
-				if i == 3: selection_string = one_jet_tagged_string
-				if i == 4: selection_string = two_jet_tagged_string
+				if i == 1: selection_string = jet_string
+				if i == 2: selection_string = one_jet_tagged_string
+				if i == 3: selection_string = two_jet_tagged_string
 				# triggered jet
-				if i == 6: 
-					selection_string = "  ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1)"
-					selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1) || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1)"
-					selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1))"
-				if i == 7: 
-					selection_string = " ( (  jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 0 condition
-					selection_string += " || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 1 condition
-					selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 2 condition
-					selection_string += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 3 condition
-					selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 4 condition
-					selection_string += " || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 5 condition
-				if i == 8: 
-					selection_string = " ( ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 1 condition
-					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 2 condition
-					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 3 condition
-					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 4 condition
-					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 5 condition
-					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 2 condition
-					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 3 condition
-					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 4 condition
-					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 5 condition
-					selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 3 condition
-					selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 4 condition
-					selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 5 condition
-					selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 4 condition
-					selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 5 condition
-					selection_string += " || ((jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
+				if i == 5: selection_string = jet_string_triggered
+				if i == 6: selection_string = one_jet_tagged_string_triggered
+				if i == 7: selection_string = two_jet_tagged_string_triggered
 				# Non-triggered jet
-				if i == 10: 
-					selection_string = "  ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0)"
-					selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0) || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0)"
-					selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0))"
-				if i == 11: 
-					selection_string = " ( (  jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 0 condition
-					selection_string += " || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 1 condition
-					selection_string += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 2 condition
-					selection_string += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 3 condition
-					selection_string += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 4 condition
-					selection_string += " || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 5 condition
-				if i == 12: 
-					selection_string = " ( ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 1 condition
-					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 2 condition
-					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 3 condition
-					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 4 condition
-					selection_string += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 5 condition
-					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 2 condition
-					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 3 condition
-					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 4 condition
-					selection_string += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 5 condition
-					selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 3 condition
-					selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 4 condition
-					selection_string += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 5 condition
-					selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 4 condition
-					selection_string += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 5 condition
-					selection_string += " || ((jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
+				if i == 9: selection_string = jet_string_not_triggered
+				if i == 10: selection_string = one_jet_tagged_string_not_triggered
+				if i == 11: selection_string = two_jet_tagged_string_not_triggered
 
 				selval = tree.GetEntries(selection_string)
-				if i % 4 == 2: all_events = selval # i = 2, 6, 10
-				if i % 4 == 3: one_plus_jets = selval # i = 3, 7, 11
-				if i % 4 == 0: two_plus_jets = selval # i = 4, 8, 12
+				if i % 4 == 1: all_events = selval # i = 1, 5, 9
+				if i % 4 == 2: one_plus_jets = selval # i = 2, 6, 10
+				if i % 4 == 3: two_plus_jets = selval # i = 3, 7, 11
 				Nevents = tree.GetEntries()
 
 				if print_latex:
-					if i < 2: print(selname+" &", round(selval, 4), "&\\multicolumn{2}{l}{", round(selval/init, 4), "} \\\\ ")
-					if i % 4 == 2: print(selname+" &", round(selval, 4), "&", round(selval/init, 4), "&", round(selval/all_events, 4), " \\\\ ")
-					if i % 4 == 3 and tree_sel != "NoSel": print(selname+" &", round(all_events - one_plus_jets, 4), "&", round((all_events - one_plus_jets)/init, 4),  "&", round((all_events - one_plus_jets)/all_events, 4), " \\\\ ") # 0 bin is all events - events with at least 1
-					if i > 0 and i % 4 == 0: print(selname+" &", round(one_plus_jets - two_plus_jets, 4), "&", round((one_plus_jets - two_plus_jets)/init, 4),  "&", round((one_plus_jets - two_plus_jets)/all_events, 4), " \\\\ ") # 1 bin is events with at least 1 - events with at least 2
-					if i >= 5 and i % 4 == 1: 
+					if i == 0: print(selname+" &", round(selval, 4), "&\\multicolumn{2}{l}{", round(selval/init, 4), "} \\\\ ")
+					if i % 4 == 1: print(selname+" &", round(selval, 4), "&", round(selval/init, 4), "&", round(selval/all_events, 4), " \\\\ ")
+					if i % 4 == 2 and tree_sel != "NoSel": print(selname+" &", round(all_events - one_plus_jets, 4), "&", round((all_events - one_plus_jets)/init, 4),  "&", round((all_events - one_plus_jets)/all_events, 4), " \\\\ ") # 0 bin is all events - events with at least 1
+					if i % 4 == 3: print(selname+" &", round(one_plus_jets - two_plus_jets, 4), "&", round((one_plus_jets - two_plus_jets)/init, 4),  "&", round((one_plus_jets - two_plus_jets)/all_events, 4), " \\\\ ") # 1 bin is events with at least 1 - events with at least 2
+					if i >= 4 and i % 4 == 0: 
 						print(selname+" &", round(two_plus_jets, 4), "&", round(two_plus_jets/init, 4),  "&", round(two_plus_jets/all_events, 4), " \\\\ ") # 2+ bin is events with at least 2
-						if i != 13: print("\\hline")
-						if i == 13: latex_end(file_path)
+						if i != 12: print("\\hline")
+						if i == 12: latex_end(file_path)
 
 				else:
 					print(selection_list_abbrev[i], "\t", Nevents, "\t", round(selval, 4), "\t", round(selval/init, 4))

--- a/CutflowAnalysis/BkgEstimation.py
+++ b/CutflowAnalysis/BkgEstimation.py
@@ -157,6 +157,51 @@ def main():
 	two_jet_tagged_string_not_triggered += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 5 condition
 	two_jet_tagged_string_not_triggered += " || ((jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
 
+
+	jet_string_matched = "  ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched >= 0) || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched >= 0)"
+	jet_string_matched += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched >= 0) || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched >= 0)"
+	jet_string_matched += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched >= 0) || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched >= 0))"
+
+	one_jet_tagged_string_matched = " ( (  jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched >= 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 0 condition
+	one_jet_tagged_string_matched += " || (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched >= 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 1 condition
+	one_jet_tagged_string_matched += " || (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched >= 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 2 condition
+	one_jet_tagged_string_matched += " || (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched >= 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 3 condition
+	one_jet_tagged_string_matched += " || (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched >= 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")" # jet 4 condition
+	one_jet_tagged_string_matched += " || (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched >= 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 5 condition
+
+	two_jet_tagged_string_matched = " ( ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched >= 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched >= 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 1 condition
+	two_jet_tagged_string_matched += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched >= 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched >= 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 2 condition
+	two_jet_tagged_string_matched += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched >= 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched >= 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 3 condition
+	two_jet_tagged_string_matched += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched >= 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched >= 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 4 condition
+	two_jet_tagged_string_matched += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched >= 0 && jet0_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched >= 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 0 AND 5 condition
+	two_jet_tagged_string_matched += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched >= 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched >= 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 2 condition
+	two_jet_tagged_string_matched += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched >= 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched >= 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 3 condition
+	two_jet_tagged_string_matched += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched >= 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched >= 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 4 condition
+	two_jet_tagged_string_matched += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched >= 0 && jet1_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched >= 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 1 AND 5 condition
+	two_jet_tagged_string_matched += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched >= 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched >= 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 3 condition
+	two_jet_tagged_string_matched += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched >= 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched >= 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 4 condition
+	two_jet_tagged_string_matched += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched >= 0 && jet2_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched >= 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 2 AND 5 condition
+	two_jet_tagged_string_matched += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched >= 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched >= 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 4 condition
+	two_jet_tagged_string_matched += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched >= 0 && jet3_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched >= 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+"))" # jet 3 AND 5 condition
+	two_jet_tagged_string_matched += " || ((jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched >= 0 && jet4_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+") && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched >= 0 && jet5_bdtscoreX_LLP350_MS80_perJet >= "+BDT_score+")))" # jet 4 AND 5 condition
+
+
+	two_jet_string_triggered = " ( ( ( jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 ) && (jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 ))" # jet 0 AND 1 condition
+	two_jet_string_triggered += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 ) && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 ))" # jet 0 AND 2 condition
+	two_jet_string_triggered += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 ) && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 ))" # jet 0 AND 3 condition
+	two_jet_string_triggered += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 ) && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 ))" # jet 0 AND 4 condition
+	two_jet_string_triggered += " || ((jet0_Pt >= "+jet_energy+" && abs(jet0_Eta) <= 1.26 && jet0_L1trig_Matched == 1 ) && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 ))" # jet 0 AND 5 condition
+	two_jet_string_triggered += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 ) && (jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 ))" # jet 1 AND 2 condition
+	two_jet_string_triggered += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 ) && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 ))" # jet 1 AND 3 condition
+	two_jet_string_triggered += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 ) && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 ))" # jet 1 AND 4 condition
+	two_jet_string_triggered += " || ((jet1_Pt >= "+jet_energy+" && abs(jet1_Eta) <= 1.26 && jet1_L1trig_Matched == 1 ) && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 ))" # jet 1 AND 5 condition
+	two_jet_string_triggered += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 ) && (jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 ))" # jet 2 AND 3 condition
+	two_jet_string_triggered += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 ) && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 ))" # jet 2 AND 4 condition
+	two_jet_string_triggered += " || ((jet2_Pt >= "+jet_energy+" && abs(jet2_Eta) <= 1.26 && jet2_L1trig_Matched == 1 ) && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 ))" # jet 2 AND 5 condition
+	two_jet_string_triggered += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 ) && (jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 ))" # jet 3 AND 4 condition
+	two_jet_string_triggered += " || ((jet3_Pt >= "+jet_energy+" && abs(jet3_Eta) <= 1.26 && jet3_L1trig_Matched == 1 ) && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 ))" # jet 3 AND 5 condition
+	two_jet_string_triggered += " || ((jet4_Pt >= "+jet_energy+" && abs(jet4_Eta) <= 1.26 && jet4_L1trig_Matched == 1 ) && (jet5_Pt >= "+jet_energy+" && abs(jet5_Eta) <= 1.26 && jet5_L1trig_Matched == 1 )))" # jet 4 AND 5 condition
+
 	HLT_string = "(( HLT_HT200_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT240_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT280_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1)"
 	HLT_string += "|| ( HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT270_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet60_DisplacedTrack == 1 )"
 	HLT_string += "|| ( HLT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive == 1 || HLT_HT420_L1SingleLLPJet_DisplacedDijet60_Inclusive == 1 )"
@@ -373,6 +418,11 @@ def main():
             "HLT and 0 jets with BDT score $\\geq "+BDT_score+"$",
             "HLT and 1 jet with BDT score $\\geq "+BDT_score+"$",
             "HLT and 2+ jets with BDT scores $\\geq "+BDT_score+"$",
+			"Jet $\\geq "+jet_energy+"$~GeV $p_T$, $\\abs\\eta \\leq 1.26$, L1 matched",
+			"LLP HLT passed",
+            "HLT and 0 jets with BDT score $\\geq "+BDT_score+"$",
+            "HLT and 1 jet with BDT score $\\geq "+BDT_score+"$",
+            "HLT and 2+ jets with BDT scores $\\geq "+BDT_score+"$",
 		]
 	
 		selection_list_abbrev_noCut = [
@@ -391,6 +441,11 @@ def main():
             "HLT and Jet BDT passed",
             "HLT and Two jet BDT passed",
 			"Not triggered", 
+			"HLT passed",
+			"HLT and No jet BDT passed",
+            "HLT and Jet BDT passed",
+            "HLT and Two jet BDT passed",
+			"L1 matched", 
 			"HLT passed",
 			"HLT and No jet BDT passed",
             "HLT and Jet BDT passed",
@@ -422,25 +477,28 @@ def main():
 			if i == 16: total_selection_string = one_jet_tagged_string_not_triggered
 			if i == 17: total_selection_string = two_jet_tagged_string_not_triggered
 
-			if i >= 5 and i != 9 and i != 14: total_selection_string += " && " + HLT_string # i == 9, 14 are for triggered / not, without HLT requirement
+			if i == 19 or i == 20: total_selection_string = jet_string_matched
+			if i == 21: total_selection_string = one_jet_tagged_string_matched
+			if i == 22: total_selection_string = two_jet_tagged_string_matched
+
+			if i >= 5 and i != 9 and i != 14 and i != 19: total_selection_string += " && " + HLT_string # i == 9, 14, 19 are for triggered / not, without HLT requirement
 
 			selval = tree.GetEntries(total_selection_string)
-			if i == 1 or i == 9 or i == 14: valid_events = selval # all valid events, triggered valid events, non-triggered valid events
-			if (i % 4 == 1 and i <= 5) or i == 10 or i == 15: all_events = selval # i == 1, 5, 9, 14 # do comparison (denominator) to all LLP events and valid events both
-			if (i % 4 == 2 and i <= 6) or i == 11 or i == 16: one_plus_jets = selval # i == 2, 6, 11, 16
-			if i == 16: print(all_events, " = all events, one plus jets = ", one_plus_jets)
-			if (i % 4 == 3 and i <= 7) or i == 12 or i == 17: two_plus_jets = selval # i == 3, 7, 12, 17
+			if i == 1 or i == 9 or i == 14 or i == 19: valid_events = selval # all valid events, triggered valid events, non-triggered valid events
+			if (i % 4 == 1 and i <= 5) or i == 10 or i == 15 or i == 20: all_events = selval # i == 1, 5, 9, 14 # do comparison (denominator) to all LLP events and valid events both
+			if (i % 4 == 2 and i <= 6) or i == 11 or i == 16 or i == 21: one_plus_jets = selval # i == 2, 6, 11, 16
+			if (i % 4 == 3 and i <= 7) or i == 12 or i == 17 or i == 22: two_plus_jets = selval # i == 3, 7, 12, 17
 
 			Nevents = tree.GetEntries()
 
 			if print_latex:
 				if i == 0: print(selname+" &", round(selval, 4), "&\\multicolumn{2}{l}{", round(selval/init, 4), "} \\\\ ")
-				if (i % 4 == 1 and i <= 9) or i == 10 or i == 14 or i == 15: print(selname+" &", round(selval, 4), " &", round(selval/init, 4), " &", round(selval/valid_events, 4), " \\\\ ")
-				if (i % 4 == 2 and i <= 6) or i == 11 or i == 16: print(selname+" & ", round(all_events - one_plus_jets, 4), " &", round((all_events - one_plus_jets)/init, 4), " &", round((all_events - one_plus_jets)/valid_events, 4), " \\\\ ") # 0 bin is all events - events with at least 1
-				if (i % 4 == 3 and i <= 7) or i == 12 or i == 17: print(selname+" & ", round(one_plus_jets - two_plus_jets, 4), " &", round((one_plus_jets - two_plus_jets)/init, 4), " &", round((one_plus_jets - two_plus_jets)/valid_events, 4), " \\\\ ") # 1 bin is events with at least 1 - events with at least 2
-				if (i % 4 == 0 and i <= 8) or i == 13 or i == 18: 
+				if (i % 4 == 1 and i <= 9) or i == 10 or i == 14 or i == 15 or i == 19 or i == 20: print(selname+" &", round(selval, 4), " &", round(selval/init, 4), " &", round(selval/valid_events, 4), " \\\\ ")
+				if (i % 4 == 2 and i <= 6) or i == 11 or i == 16 or i == 21: print(selname+" & ", round(all_events - one_plus_jets, 4), " &", round((all_events - one_plus_jets)/init, 4), " &", round((all_events - one_plus_jets)/valid_events, 4), " \\\\ ") # 0 bin is all events - events with at least 1
+				if (i % 4 == 3 and i <= 7) or i == 12 or i == 17 or i == 22: print(selname+" & ", round(one_plus_jets - two_plus_jets, 4), " &", round((one_plus_jets - two_plus_jets)/init, 4), " &", round((one_plus_jets - two_plus_jets)/valid_events, 4), " \\\\ ") # 1 bin is events with at least 1 - events with at least 2
+				if (i % 4 == 0 and i <= 8) or i == 13 or i == 18 or i == 23: 
 					if i >= 4: print(selname+" & ", round(two_plus_jets, 4), " & ", round(two_plus_jets/init, 4), " & ", round(two_plus_jets/valid_events, 4), " \\\\ ") # 2+ bin is events with at least 2
-					if i != 18: print("\\hline")
+					if i != 23: print("\\hline")
 					else: latex_end(file_path)
 
 			else:
@@ -521,6 +579,58 @@ def main():
 		print("Background (W+jets, then NoSel) cutflow, done per event")
 		print(" \n")
 
+		# Check how many events in bkg have 2 jets triggered 
+		event_selection_list = [
+            "All events (from skim)", 
+			"Jet $\\geq "+jet_energy+"$~GeV $p_T$ and $\\abs\\eta \\leq 1.26$", # (one of 6 leading)", 
+			"Jet $\\geq "+jet_energy+"$~GeV $p_T$, $\\abs\\eta \\leq 1.26$, triggered",
+			"2 jets $\\geq "+jet_energy+"$~GeV $p_T$, $\\abs\\eta \\leq 1.26$, triggered"
+        ]
+        
+		event_selection_list_abbrev = [
+            "All       ", 
+            "Jet pT and eta", 
+            "Jet eta, pT (triggered)",
+            "2 jets eta, pT (triggered)"
+        ]
+
+		trees = ["WPlusJets"]
+		for tree_sel in trees:
+			print("\n Running for: " + tree_sel + " \n")
+			file = ROOT.TFile.Open(file_path)
+			tree = file.Get(tree_sel)
+			
+			selection_string = ""
+			
+			if print_latex:
+				jetSplit_event_latex_setup(file_path)
+
+			init = -1
+			
+			for i in range(len(event_selection_list)):
+				selname = event_selection_list[i]
+				selval  = -1
+				Nevents = -1
+
+				if i == 0: 
+					selval = tree.GetEntries()
+					init = selval
+				if i == 1: selection_string = jet_string
+				# triggered jet
+				if i == 2: selection_string = jet_string_triggered
+				if i == 3: selection_string = two_jet_string_triggered
+
+				selval = tree.GetEntries(selection_string)
+				if i == 1: all_events = selval # i = 1, 5, 9
+
+				if print_latex:
+					if i == 0: print(selname+" &", round(selval, 4), "&\\multicolumn{2}{l}{", round(selval/init, 4), "} \\\\ ")
+					if i >= 1: print(selname+" &", round(selval, 4), "&", round(selval/init, 4), "&", round(selval/all_events, 4), " \\\\ ")
+					if i == 3: 
+						print("\\hline")
+						latex_end(file_path)
+						
+
 		event_selection_list = [
             "All events (from skim)", 
 			"Jet $\\geq "+jet_energy+"$~GeV $p_T$ and $\\abs\\eta \\leq 1.26$", # (one of 6 leading)", 
@@ -532,6 +642,10 @@ def main():
             "1 jet with BDT score $\\geq "+BDT_score+"$",
             "2+ jets with BDT scores $\\geq "+BDT_score+"$",
 			"Jet $\\geq "+jet_energy+"$~GeV $p_T$, $\\abs\\eta \\leq 1.26$, not triggered",
+			"0 jets with BDT score $\\geq "+BDT_score+"$",
+            "1 jet with BDT score $\\geq "+BDT_score+"$",
+            "2+ jets with BDT scores $\\geq "+BDT_score+"$",
+			"Jet $\\geq "+jet_energy+"$~GeV $p_T$, $\\abs\\eta \\leq 1.26$, L1 matched",
 			"0 jets with BDT score $\\geq "+BDT_score+"$",
             "1 jet with BDT score $\\geq "+BDT_score+"$",
             "2+ jets with BDT scores $\\geq "+BDT_score+"$",
@@ -548,6 +662,10 @@ def main():
             "Jet BDT passed",
             "Two jet BDT passed",
             "Jet eta, pT (not triggered)",
+            "No jet BDT passed",
+            "Jet BDT passed",
+            "Two jet BDT passed",
+            "Jet eta, pT (L1 matched)",
             "No jet BDT passed",
             "Jet BDT passed",
             "Two jet BDT passed",
@@ -590,11 +708,15 @@ def main():
 				if i == 9: selection_string = jet_string_not_triggered
 				if i == 10: selection_string = one_jet_tagged_string_not_triggered
 				if i == 11: selection_string = two_jet_tagged_string_not_triggered
+				# L1 matched jet
+				if i == 13: selection_string = jet_string_matched
+				if i == 14: selection_string = one_jet_tagged_string_matched
+				if i == 15: selection_string = two_jet_tagged_string_matched
 
 				selval = tree.GetEntries(selection_string)
-				if i % 4 == 1: all_events = selval # i = 1, 5, 9
-				if i % 4 == 2: one_plus_jets = selval # i = 2, 6, 10
-				if i % 4 == 3: two_plus_jets = selval # i = 3, 7, 11
+				if i % 4 == 1: all_events = selval # i = 1, 5, 9, 13
+				if i % 4 == 2: one_plus_jets = selval # i = 2, 6, 10, 14
+				if i % 4 == 3: two_plus_jets = selval # i = 3, 7, 11, 15
 				Nevents = tree.GetEntries()
 
 				if print_latex:
@@ -604,8 +726,8 @@ def main():
 					if i % 4 == 3: print(selname+" &", round(one_plus_jets - two_plus_jets, 4), "&", round((one_plus_jets - two_plus_jets)/init, 4),  "&", round((one_plus_jets - two_plus_jets)/all_events, 4), " \\\\ ") # 1 bin is events with at least 1 - events with at least 2
 					if i >= 4 and i % 4 == 0: 
 						print(selname+" &", round(two_plus_jets, 4), "&", round(two_plus_jets/init, 4),  "&", round(two_plus_jets/all_events, 4), " \\\\ ") # 2+ bin is events with at least 2
-						if i != 12: print("\\hline")
-						if i == 12: latex_end(file_path)
+						if i != 16: print("\\hline")
+						if i == 16: latex_end(file_path)
 
 				else:
 					print(selection_list_abbrev[i], "\t", Nevents, "\t", round(selval, 4), "\t", round(selval/init, 4))

--- a/CutflowAnalysis/BkgEstimationPlot.py
+++ b/CutflowAnalysis/BkgEstimationPlot.py
@@ -33,9 +33,10 @@ cmsLabel2 = "#scale[0.8]{#sqrt{s} = 13.6 TeV}"
 # list inputs and number of events in each bin
 inputs = ["W+Jets", "LLP MC", "LLP MC passed HLT"] # currently for 350, 80
 
-zero_bin = [21906/21907, 0.9315, 0.0498]
-one_bin = [1/21907, 0.067, 0.037]
-two_bin = [0, 0.0015, 0.0012]
+zero_bin = [21906, 232685, 12447] # second column is comparing to all valid events, last is also comparing to all valid, but require HTL is set (so won't add to 1)
+one_bin = [1, 16745, 9242]
+two_bin = [0, 374, 293]
+totals = [21907, 249804, 249804]
 
 stack = False
 if stack: hs = ROOT.THStack("hs",  "Fraction of events with BDT tagged jets (mH = 350, mS = 80 GeV); Fraction of events with jets with BDT discriminator > 0.9999;Fraction of Events")
@@ -53,6 +54,12 @@ for type in inputs:
     JetsPerCategory[hname].SetBinContent(1, zero_bin[i]) 
     JetsPerCategory[hname].SetBinContent(2, one_bin[i]) 
     JetsPerCategory[hname].SetBinContent(3, two_bin[i]) 
+    if zero_bin[i] > 0: JetsPerCategory[hname].SetBinError(1, sqrt(1/zero_bin[i]))
+    if one_bin[i] > 0: JetsPerCategory[hname].SetBinError(2, sqrt(1/one_bin[i]))
+    if two_bin[i] > 0: JetsPerCategory[hname].SetBinError(3, sqrt(1/two_bin[i])) 
+
+    JetsPerCategory[hname].Scale(1/totals[i])
+
     JetsPerCategory[hname].SetLineWidth(3)
     JetsPerCategory[hname].GetXaxis().SetBinLabel(1,"0 tagged jets")
     JetsPerCategory[hname].GetXaxis().SetBinLabel(2,"1 tagged jet")
@@ -60,8 +67,8 @@ for type in inputs:
     if "LLP" not in type:
         JetsPerCategory[hname].SetFillStyle(3004)
     if not stack:
-        if i == 0: JetsPerCategory[hname].Draw("PLC PFC")
-        else: JetsPerCategory[hname].Draw("SAME PLC")
+        if i == 0: JetsPerCategory[hname].Draw("HIST PLC PFC E1")
+        else: JetsPerCategory[hname].Draw("SAME HIST PLC E1")
     i += 1
     if stack: hs.Add(JetsPerCategory[hname])
 

--- a/CutflowAnalysis/BkgEstimationPlot.py
+++ b/CutflowAnalysis/BkgEstimationPlot.py
@@ -33,9 +33,9 @@ cmsLabel2 = "#scale[0.8]{#sqrt{s} = 13.6 TeV}"
 # list inputs and number of events in each bin
 inputs = ["W+Jets", "LLP MC", "LLP MC passed HLT"] # currently for 350, 80
 
-zero_bin = [21906/21907, 0.7779, 0.0416]
-one_bin = [1/21907, 0.056, 0.309]
-two_bin = [0, 0.0013, 0.0009796]
+zero_bin = [21906/21907, 0.9315, 0.0498]
+one_bin = [1/21907, 0.067, 0.037]
+two_bin = [0, 0.0015, 0.0012]
 
 stack = False
 if stack: hs = ROOT.THStack("hs",  "Fraction of events with BDT tagged jets (mH = 350, mS = 80 GeV); Fraction of events with jets with BDT discriminator > 0.9999;Fraction of Events")
@@ -71,3 +71,4 @@ stamp_text.DrawLatex(xpos, ypos, cmsLabel)
 #stamp_text.DrawLatex(xpos, ypos-0.04, cmsLabel2)
 legend.Draw()
 canv.SaveAs("NumberTagged.png")
+canv.SaveAs("NumberTagged.pdf")

--- a/CutflowAnalysis/BkgEstimationPlot.py
+++ b/CutflowAnalysis/BkgEstimationPlot.py
@@ -37,6 +37,7 @@ zero_bin = [21906, 232685, 12447] # second column is comparing to all valid even
 one_bin = [1, 16745, 9242]
 two_bin = [0, 374, 293]
 totals = [21907, 249804, 249804]
+# totals = [21907, 249804, 21982]
 
 stack = False
 if stack: hs = ROOT.THStack("hs",  "Fraction of events with BDT tagged jets (mH = 350, mS = 80 GeV); Fraction of events with jets with BDT discriminator > 0.9999;Fraction of Events")

--- a/CutflowAnalysis/BkgEstimationPlot.py
+++ b/CutflowAnalysis/BkgEstimationPlot.py
@@ -54,9 +54,9 @@ for type in inputs:
     JetsPerCategory[hname].SetBinContent(1, zero_bin[i]) 
     JetsPerCategory[hname].SetBinContent(2, one_bin[i]) 
     JetsPerCategory[hname].SetBinContent(3, two_bin[i]) 
-    if zero_bin[i] > 0: JetsPerCategory[hname].SetBinError(1, sqrt(1/zero_bin[i]))
-    if one_bin[i] > 0: JetsPerCategory[hname].SetBinError(2, sqrt(1/one_bin[i]))
-    if two_bin[i] > 0: JetsPerCategory[hname].SetBinError(3, sqrt(1/two_bin[i])) 
+    if zero_bin[i] > 0: JetsPerCategory[hname].SetBinError(1, sqrt(zero_bin[i]))
+    if one_bin[i] > 0: JetsPerCategory[hname].SetBinError(2, sqrt(one_bin[i]))
+    if two_bin[i] > 0: JetsPerCategory[hname].SetBinError(3, sqrt(two_bin[i])) 
 
     JetsPerCategory[hname].Scale(1/totals[i])
 

--- a/CutflowAnalysis/BkgEstimationPlot.py
+++ b/CutflowAnalysis/BkgEstimationPlot.py
@@ -31,23 +31,23 @@ cmsLabel = "#scale[1.0]{#bf{CMS} #it{Internal}}"
 cmsLabel2 = "#scale[0.8]{#sqrt{s} = 13.6 TeV}"
 
 # list inputs and number of events in each bin
-inputs = ["W+Jets", "LLP MC"]
+inputs = ["W+Jets", "LLP MC", "LLP MC passed HLT"] # currently for 350, 80
 
-zero_bin = [49925, 3]
-one_bin = [70, 65]
-two_bin = [1, 272]
+zero_bin = [21906/21907, 0.7779, 0.0416]
+one_bin = [1/21907, 0.056, 0.309]
+two_bin = [0, 0.0013, 0.0009796]
 
 stack = False
-if stack: hs = ROOT.THStack("hs",  "Number of BDT tagged jets in an event; Number of jets with BDT discriminator > 0.99;Number of Events")
+if stack: hs = ROOT.THStack("hs",  "Fraction of events with BDT tagged jets (mH = 350, mS = 80 GeV); Fraction of events with jets with BDT discriminator > 0.9999;Fraction of Events")
 
 JetsPerCategory = {}
-legend = ROOT.TLegend(0.65,0.65,0.85,0.8)
+legend = ROOT.TLegend(0.68,0.65,0.88,0.8)
 canv.cd()
 
 i = 0
 for type in inputs:
     hname = type
-    JetsPerCategory[hname] = ROOT.TH1F(hname, "Number of BDT tagged jets in an event;Number of jets with BDT discriminator > 0.99;Number of Events", 3, 0, 3) 
+    JetsPerCategory[hname] = ROOT.TH1F(hname, "Fraction of events with BDT tagged jets (mH = 350, mS = 80 GeV);Fraction of events with jets with BDT discriminator > 0.9999;Fraction of Events", 3, 0, 3) 
     legend.AddEntry(JetsPerCategory[hname], type)
 
     JetsPerCategory[hname].SetBinContent(1, zero_bin[i]) 
@@ -60,7 +60,7 @@ for type in inputs:
     if "LLP" not in type:
         JetsPerCategory[hname].SetFillStyle(3004)
     if not stack:
-        if i == 0: JetsPerCategory[hname].Draw("PFC")
+        if i == 0: JetsPerCategory[hname].Draw("PLC PFC")
         else: JetsPerCategory[hname].Draw("SAME PLC")
     i += 1
     if stack: hs.Add(JetsPerCategory[hname])

--- a/CutflowAnalysis/ExpectedLimitsPlot.py
+++ b/CutflowAnalysis/ExpectedLimitsPlot.py
@@ -1,0 +1,76 @@
+import ROOT
+from ROOT import Form
+from math import *
+import numpy as np
+import sys, os, argparse, time, errno
+import matplotlib.pyplot as plt
+from datetime import datetime
+
+start = time.time()
+
+debug = False
+time_debug = False
+
+# set ROOT canvas information
+ROOT.gROOT.SetBatch(1)
+ROOT.gStyle.SetOptStat(0)
+ROOT.gStyle.SetEndErrorSize(0)
+ROOT.gStyle.SetPalette(ROOT.kCandy)
+
+stamp_text = ROOT.TLatex()
+stamp_text.SetNDC()
+stamp_text.SetTextFont(42)
+stamp_text.SetTextColor(ROOT.kBlack)
+stamp_text.SetTextSize(0.045)
+xpos = 0.7
+ypos = 0.85
+
+canv = ROOT.TCanvas("c","c",800,600)
+
+cmsLabel = "#scale[1.0]{#bf{CMS} #it{Internal}}"
+cmsLabel2 = "#scale[0.8]{#sqrt{s} = 13.6 TeV}"
+
+# list inputs and number of events in each bin
+inputs = ["LLP 125, 15", "LLP 125, 50", "LLP 250, 120", "LLP 350, 50", "LLP 350, 160"]
+
+ctau_pt5 = [-1, -1, -1, 0.094, -1]
+ctau_1 = [13.5, -1, -1, -1, -1]
+ctau_3 = [-1, 0.71, -1, -1, -1]
+ctau_10 = [-1, -1, 0.56, -1, 0.26]
+
+stack = False
+if stack: hs = ROOT.THStack("hs",  "Expected Limits; LLP c#tau;Branching Ratio")
+
+JetsPerCategory = {}
+legend = ROOT.TLegend(0.68,0.65,0.88,0.8)
+canv.cd()
+
+i = 0
+for type in inputs:
+    hname = type
+    JetsPerCategory[hname] = ROOT.TH1F(hname, "Expected Limits;LLP c#tau;Branching Ratio", 4, 0, 4) 
+    legend.AddEntry(JetsPerCategory[hname], type)
+
+    JetsPerCategory[hname].SetBinContent(1, ctau_pt5[i]) 
+    JetsPerCategory[hname].SetBinContent(2, ctau_1[i]) 
+    JetsPerCategory[hname].SetBinContent(3, ctau_3[i]) 
+    JetsPerCategory[hname].SetBinContent(4, ctau_10[i]) 
+    JetsPerCategory[hname].SetMarkerSize(1.5)
+    JetsPerCategory[hname].SetMarkerStyle(21)
+    JetsPerCategory[hname].GetXaxis().SetBinLabel(1,"c#tau = 0.5 m")
+    JetsPerCategory[hname].GetXaxis().SetBinLabel(2,"c#tau = 1 m")
+    JetsPerCategory[hname].GetXaxis().SetBinLabel(3,"c#tau = 3 m")
+    JetsPerCategory[hname].GetXaxis().SetBinLabel(4,"c#tau = 10 m")
+    if "LLP" not in type:
+        JetsPerCategory[hname].SetFillStyle(3004)
+    if not stack:
+        if i == 0: JetsPerCategory[hname].Draw("P PMC")
+        else: JetsPerCategory[hname].Draw("SAME P PMC")
+    i += 1
+    if stack: hs.Add(JetsPerCategory[hname])
+
+ROOT.gPad.SetLogy()
+if stack: hs.Draw("HIST PLC nostack")
+stamp_text.DrawLatex(xpos, ypos, cmsLabel)
+legend.Draw()
+canv.SaveAs("ExpectedLimits.png")

--- a/CutflowAnalysis/ExpectedLimitsPlot.py
+++ b/CutflowAnalysis/ExpectedLimitsPlot.py
@@ -31,12 +31,23 @@ cmsLabel = "#scale[1.0]{#bf{CMS} #it{Internal}}"
 cmsLabel2 = "#scale[0.8]{#sqrt{s} = 13.6 TeV}"
 
 # list inputs and number of events in each bin
-inputs = ["mH=125, mS=15", "mH=125, mS=50", "mH=250, mS=120", "mH=350, mS=50", "mH=350, mS=160"]
+inputs = ["mH=125, mS=15", "mH=125, mS=50", "mH=250, mS=120", "mH=350, mS=80", "mH=350, mS=160"]
 
-ctau_pt5 = [-1, -1, -1, 0.00094, -1]
-ctau_1 = [0.135, -1, -1, -1, -1]
-ctau_3 = [-1, 0.0071, -1, -1, -1]
-ctau_10 = [-1, -1, 0.0056, -1, 0.0026]
+overall_acceptance = [2/292437, 382/2943719, 487/2937728, 293/299110, 1043/2946400]
+
+ctau_pt5 = [-1, -1, -1, 293/299110, -1]
+ctau_1 = [2/292437, -1, -1, -1, -1]
+ctau_3 = [-1, 382/2943719, -1, -1, -1]
+ctau_10 = [-1, -1, 487/2937728, -1, 1043/2946400]
+
+n_pass = [2, 382, 487, 293, 1043]
+n_total = [292437, 2943719, 2937728, 299110, 2946400]
+
+# Full calculation results below
+#ctau_pt5 = [-1, -1, -1, 0.00094, -1]
+#ctau_1 = [0.135, -1, -1, -1, -1]
+#ctau_3 = [-1, 0.0071, -1, -1, -1]
+#ctau_10 = [-1, -1, 0.0056, -1, 0.0026]
 
 stack = False
 if stack: hs = ROOT.THStack("hs",  "Expected Limits based on BDT double jet tag; LLP c#tau;Branching Ratio")
@@ -63,10 +74,16 @@ for type in inputs:
         bin3 = 7
         bin4 = 19
 
-    JetsPerCategory[hname].SetBinContent(bin1, ctau_pt5[i]) 
-    JetsPerCategory[hname].SetBinContent(bin2, ctau_1[i]) 
-    JetsPerCategory[hname].SetBinContent(bin3, ctau_3[i]) 
-    JetsPerCategory[hname].SetBinContent(bin4, ctau_10[i]) 
+    JetsPerCategory[hname].SetBinContent(bin1, 3 / (67 * ctau_pt5[i] * 48520)) 
+    if (ctau_pt5[i] > 0): JetsPerCategory[hname].SetBinError(bin1, 3 / (67 * ctau_pt5[i] * 48520) * sqrt(ctau_pt5[i] * (1-ctau_pt5[i])/n_total[i]) * 1/ctau_pt5[i] ) # binomial errors 
+    JetsPerCategory[hname].SetBinContent(bin2, 3 / (67 * ctau_1[i] * 48520)) 
+    if (ctau_1[i] > 0): JetsPerCategory[hname].SetBinError(bin2, 3 / (67 * ctau_1[i] * 48520) * sqrt(ctau_1[i] * (1-ctau_1[i])/n_total[i]) * 1/ctau_1[i] ) 
+    JetsPerCategory[hname].SetBinContent(bin3, 3 / (67 * ctau_3[i] * 48520)) 
+    if (ctau_3[i] > 0): JetsPerCategory[hname].SetBinError(bin3, 3 / (67 * ctau_3[i] * 48520) * sqrt(ctau_3[i] * (1-ctau_3[i])/n_total[i]) * 1/ctau_3[i] ) 
+    JetsPerCategory[hname].SetBinContent(bin4, 3 / (67 * ctau_10[i] * 48520)) 
+    if (ctau_10[i] > 0): JetsPerCategory[hname].SetBinError(bin4, 3 / (67 * ctau_10[i] * 48520) * sqrt(ctau_10[i] * (1-ctau_10[i])/n_total[i]) * 1/ctau_10[i] ) 
+        # print(3 / (67 * ctau_10[i] * 48520) * sqrt(ctau_10[i] * (1-ctau_10[i])/n_total[i]) * 1/ctau_10[i]) # binomial
+        # print(3 / (67 * ctau_10[i] * 48520) * sqrt(1/n_total[i]) * 1/ctau_10[i]) # poisson
     JetsPerCategory[hname].SetMarkerSize(1.5)
     JetsPerCategory[hname].SetMarkerStyle(21)
     JetsPerCategory[hname].GetYaxis().SetRangeUser(0.00005, 1)
@@ -78,8 +95,8 @@ for type in inputs:
     if "LLP" not in type:
         JetsPerCategory[hname].SetFillStyle(3004)
     if not stack:
-        if i == 0: JetsPerCategory[hname].Draw("P PMC")
-        else: JetsPerCategory[hname].Draw("SAME P PMC")
+        if i == 0: JetsPerCategory[hname].Draw("P PMC PLC E1")
+        else: JetsPerCategory[hname].Draw("SAME P PMC PLC E1")
     i += 1
     if stack: hs.Add(JetsPerCategory[hname])
 

--- a/CutflowAnalysis/ExpectedLimitsPlot.py
+++ b/CutflowAnalysis/ExpectedLimitsPlot.py
@@ -33,13 +33,13 @@ cmsLabel2 = "#scale[0.8]{#sqrt{s} = 13.6 TeV}"
 # list inputs and number of events in each bin
 inputs = ["mH=125, mS=15", "mH=125, mS=50", "mH=250, mS=120", "mH=350, mS=50", "mH=350, mS=160"]
 
-ctau_pt5 = [-1, -1, -1, 0.094, -1]
-ctau_1 = [13.5, -1, -1, -1, -1]
-ctau_3 = [-1, 0.71, -1, -1, -1]
-ctau_10 = [-1, -1, 0.56, -1, 0.26]
+ctau_pt5 = [-1, -1, -1, 0.00094, -1]
+ctau_1 = [0.135, -1, -1, -1, -1]
+ctau_3 = [-1, 0.0071, -1, -1, -1]
+ctau_10 = [-1, -1, 0.0056, -1, 0.0026]
 
 stack = False
-if stack: hs = ROOT.THStack("hs",  "Expected Limits based on BDT double jet tag; LLP c#tau;Branching Ratio (%)")
+if stack: hs = ROOT.THStack("hs",  "Expected Limits based on BDT double jet tag; LLP c#tau;Branching Ratio")
 
 JetsPerCategory = {}
 legend = ROOT.TLegend(0.68,0.65,0.88,0.8)
@@ -49,7 +49,7 @@ i = 0
 for type in inputs:
     hname = type
     bin_num = 4 # 20 # 4
-    JetsPerCategory[hname] = ROOT.TH1F(hname, "Expected Limits based on BDT double jet tag;LLP c#tau (m);Branching Ratio (%)", bin_num, 0, bin_num) 
+    JetsPerCategory[hname] = ROOT.TH1F(hname, "Expected Limits based on BDT double jet tag;LLP c#tau (m);Branching Ratio", bin_num, 0, bin_num) 
     legend.AddEntry(JetsPerCategory[hname], type)
 
     if bin_num == 4:
@@ -69,6 +69,7 @@ for type in inputs:
     JetsPerCategory[hname].SetBinContent(bin4, ctau_10[i]) 
     JetsPerCategory[hname].SetMarkerSize(1.5)
     JetsPerCategory[hname].SetMarkerStyle(21)
+    JetsPerCategory[hname].GetYaxis().SetRangeUser(0.00005, 1)
     if bin_num == 4:
         JetsPerCategory[hname].GetXaxis().SetBinLabel(bin1,"c#tau = 0.5 m")
         JetsPerCategory[hname].GetXaxis().SetBinLabel(bin2,"c#tau = 1 m")
@@ -86,5 +87,9 @@ ROOT.gPad.SetLogy()
 if stack: hs.Draw("HIST PLC nostack")
 stamp_text.DrawLatex(xpos, ypos, cmsLabel)
 legend.Draw()
-if bin_num == 4: canv.SaveAs("ExpectedLimits_labeled.png")
-else: canv.SaveAs("ExpectedLimits.png")
+if bin_num == 4: 
+    canv.SaveAs("ExpectedLimits_labeled.png")
+    canv.SaveAs("ExpectedLimits_labeled.pdf")
+else: 
+    canv.SaveAs("ExpectedLimits.png")
+    canv.SaveAs("ExpectedLimits.pdf")

--- a/CutflowAnalysis/ExpectedLimitsPlot.py
+++ b/CutflowAnalysis/ExpectedLimitsPlot.py
@@ -31,7 +31,7 @@ cmsLabel = "#scale[1.0]{#bf{CMS} #it{Internal}}"
 cmsLabel2 = "#scale[0.8]{#sqrt{s} = 13.6 TeV}"
 
 # list inputs and number of events in each bin
-inputs = ["LLP 125, 15", "LLP 125, 50", "LLP 250, 120", "LLP 350, 50", "LLP 350, 160"]
+inputs = ["mH=125, mS=15", "mH=125, mS=50", "mH=250, mS=120", "mH=350, mS=50", "mH=350, mS=160"]
 
 ctau_pt5 = [-1, -1, -1, 0.094, -1]
 ctau_1 = [13.5, -1, -1, -1, -1]
@@ -39,7 +39,7 @@ ctau_3 = [-1, 0.71, -1, -1, -1]
 ctau_10 = [-1, -1, 0.56, -1, 0.26]
 
 stack = False
-if stack: hs = ROOT.THStack("hs",  "Expected Limits; LLP c#tau;Branching Ratio")
+if stack: hs = ROOT.THStack("hs",  "Expected Limits based on BDT double jet tag; LLP c#tau;Branching Ratio (%)")
 
 JetsPerCategory = {}
 legend = ROOT.TLegend(0.68,0.65,0.88,0.8)
@@ -48,19 +48,32 @@ canv.cd()
 i = 0
 for type in inputs:
     hname = type
-    JetsPerCategory[hname] = ROOT.TH1F(hname, "Expected Limits;LLP c#tau;Branching Ratio", 4, 0, 4) 
+    bin_num = 4 # 20 # 4
+    JetsPerCategory[hname] = ROOT.TH1F(hname, "Expected Limits based on BDT double jet tag;LLP c#tau (m);Branching Ratio (%)", bin_num, 0, bin_num) 
     legend.AddEntry(JetsPerCategory[hname], type)
 
-    JetsPerCategory[hname].SetBinContent(1, ctau_pt5[i]) 
-    JetsPerCategory[hname].SetBinContent(2, ctau_1[i]) 
-    JetsPerCategory[hname].SetBinContent(3, ctau_3[i]) 
-    JetsPerCategory[hname].SetBinContent(4, ctau_10[i]) 
+    if bin_num == 4:
+        bin1 = 1
+        bin2 = 2
+        bin3 = 3
+        bin4 = 4
+    if bin_num == 20:
+        bin1 = 2
+        bin2 = 3
+        bin3 = 7
+        bin4 = 19
+
+    JetsPerCategory[hname].SetBinContent(bin1, ctau_pt5[i]) 
+    JetsPerCategory[hname].SetBinContent(bin2, ctau_1[i]) 
+    JetsPerCategory[hname].SetBinContent(bin3, ctau_3[i]) 
+    JetsPerCategory[hname].SetBinContent(bin4, ctau_10[i]) 
     JetsPerCategory[hname].SetMarkerSize(1.5)
     JetsPerCategory[hname].SetMarkerStyle(21)
-    JetsPerCategory[hname].GetXaxis().SetBinLabel(1,"c#tau = 0.5 m")
-    JetsPerCategory[hname].GetXaxis().SetBinLabel(2,"c#tau = 1 m")
-    JetsPerCategory[hname].GetXaxis().SetBinLabel(3,"c#tau = 3 m")
-    JetsPerCategory[hname].GetXaxis().SetBinLabel(4,"c#tau = 10 m")
+    if bin_num == 4:
+        JetsPerCategory[hname].GetXaxis().SetBinLabel(bin1,"c#tau = 0.5 m")
+        JetsPerCategory[hname].GetXaxis().SetBinLabel(bin2,"c#tau = 1 m")
+        JetsPerCategory[hname].GetXaxis().SetBinLabel(bin3,"c#tau = 3 m")
+        JetsPerCategory[hname].GetXaxis().SetBinLabel(bin4,"c#tau = 10 m")
     if "LLP" not in type:
         JetsPerCategory[hname].SetFillStyle(3004)
     if not stack:
@@ -73,4 +86,5 @@ ROOT.gPad.SetLogy()
 if stack: hs.Draw("HIST PLC nostack")
 stamp_text.DrawLatex(xpos, ypos, cmsLabel)
 legend.Draw()
-canv.SaveAs("ExpectedLimits.png")
+if bin_num == 4: canv.SaveAs("ExpectedLimits_labeled.png")
+else: canv.SaveAs("ExpectedLimits.png")

--- a/DisplacedHcalJetAnalyzer/src/OutputHelper.cxx
+++ b/DisplacedHcalJetAnalyzer/src/OutputHelper.cxx
@@ -11,7 +11,7 @@ void DisplacedHcalJetAnalyzer::DeclareOutputTrees(){
 
 	cout<<"Declaring Output Trees..."<<endl;	
 
-	treenames = { "NoSel", "WPlusJets" }; 
+	treenames = { "NoSel", "PassedHLT", "WPlusJets" }; 
 
 	vector<string> myvars_bool = {};
 	
@@ -229,7 +229,7 @@ void DisplacedHcalJetAnalyzer::DeclareOutputJetTrees(){
 
 	cout<<"Declaring Output Trees..."<<endl;	
 
-	jet_treenames = { "PerJet_NoSel", "PerJet_WPlusJets", "PerJet_LLPmatched" }; 
+	jet_treenames = { "PerJet_NoSel", "PerJet_PassedHLT", "PerJet_WPlusJets", "PerJet_LLPmatched" }; 
 
 	vector<string> myvars_bool = {};
 	for (int i = 0; i < HLT_Indices.size(); i++) {
@@ -665,7 +665,7 @@ void DisplacedHcalJetAnalyzer::FillOutputJetTrees( string treename, int jetIndex
 	jet_tree_output_vars_float["eventHT"]   = EventHT();
 
 	for (int i = 0; i < HLT_Indices.size(); i++) { 
-		tree_output_vars_bool[HLT_Names[i]] = HLT_Decision->at(i);
+		jet_tree_output_vars_bool[HLT_Names[i]] = HLT_Decision->at(i);
 	}
 
 	jet_tree_output_vars_float["perJet_E"] 			= jet_E->at(jetIndex);

--- a/DisplacedHcalJetAnalyzer/src/OutputHelper.cxx
+++ b/DisplacedHcalJetAnalyzer/src/OutputHelper.cxx
@@ -664,6 +664,10 @@ void DisplacedHcalJetAnalyzer::FillOutputJetTrees( string treename, int jetIndex
 	jet_tree_output_vars_int["pho"]			= n_pho;
 	jet_tree_output_vars_float["eventHT"]   = EventHT();
 
+	for (int i = 0; i < HLT_Indices.size(); i++) { 
+		tree_output_vars_bool[HLT_Names[i]] = HLT_Decision->at(i);
+	}
+
 	jet_tree_output_vars_float["perJet_E"] 			= jet_E->at(jetIndex);
 	jet_tree_output_vars_float["perJet_Pt"] 		= jet_Pt->at(jetIndex);
 	jet_tree_output_vars_float["perJet_Eta"] 		= jet_Eta->at(jetIndex);

--- a/DisplacedHcalJetAnalyzer/src/OutputHelper.cxx
+++ b/DisplacedHcalJetAnalyzer/src/OutputHelper.cxx
@@ -587,7 +587,7 @@ void DisplacedHcalJetAnalyzer::FillOutputTrees( string treename ){
 		tree_output_vars_float[Form("LLP%d_DecayY", i)] = gLLP_DecayVtx_Y->at(i);
 		tree_output_vars_float[Form("LLP%d_DecayZ", i)] = gLLP_DecayVtx_Z->at(i);
 		tree_output_vars_float[Form("LLP%d_DecayD", i)] = distance;
-		tree_output_vars_float[Form("LLP%d_DecayT", i)] = distance * ( 1 / gLLP_Beta->at(i) - 1) * 0.03336; // 1/c in ns / cm to give answer in ns
+		tree_output_vars_float[Form("LLP%d_DecayT", i)] = distance * ( 1 / gLLP_Beta->at(i) ) * 0.03336; // 1/c in ns / cm to give answer in ns
 		tree_output_vars_float[Form("LLP%d_DecayCtau", i)] = distance * (sqrt( 1 / pow(gLLP_Beta->at(i),2) - 1)); 
 		for (int b = 0; b < 2; b++) tree_output_vars_float[Form("LLP%d_dR_LLP_to_b", i)] = DeltaR_LLP_b(i, b); 
 		tree_output_vars_float[Form("LLP%d_dR_b_to_b", i)] = DeltaR_b(i);

--- a/FakeRate/MisTagProbability.py
+++ b/FakeRate/MisTagProbability.py
@@ -55,6 +55,8 @@ def OutputFolder(name):
 
 OutputFolder("")
 
+jet_number = ["0", "1", "2", "3", "4", "5"]
+
 # path = sys.argv[1] # pass the location of the processed ntuple as an argument 
 # infile = ROOT.TFile.Open(path)
 
@@ -517,7 +519,6 @@ def Plot2D(tree, obj_type, radius):
 # ------------------------------------------------------------------------------
 def SignalJetTagged(tree1, tree2, tree3, tree4, tree5, signal_names, tree_bkg, obj_type):
     if (obj_type == "jet"):
-        number = ["0", "1", "2", "3", "4", "5"]
         LLP_matching = ["L1trig_Matched"] # jet + number + var = full histogram name
         LLP_BDTscore = ["bdtscoreX_LLP350_MS80_perJet"]
 
@@ -541,7 +542,7 @@ def SignalJetTagged(tree1, tree2, tree3, tree4, tree5, signal_names, tree_bkg, o
             TagJets_bkg = ROOT.TH1F("Tagged Jet Background " +  str(trig_matched), "Tagged Jet, for L1 jet matching=" + str(trig_matched) + " ; pT order of tagged jet; Fraction of tagged jets", 6, 0, 6 ); 
             N_tot_bkg = 0
 
-            for i in number:
+            for i in jet_number:
                 
                 selection_region = GetCut(obj_type + i + "_" + LLP_matching[0], trig_matched) # require matching trigger set or not set
                 pT_region = GetCut(obj_type + i + "_Pt", [40,1000])                         # require jet pT is over 40 GeV
@@ -619,16 +620,14 @@ def SignalJetTagged(tree1, tree2, tree3, tree4, tree5, signal_names, tree_bkg, o
 def MisTagProbability(tree, obj_type):
     
     if (obj_type == "jet"):
-        # number = ["0", "1", "2", "3", "4", "5"]
-        number = ["0"]
 
         LLP_matching = ["L1trig_Matched"] # jet + number + var = full histogram name
         LLP_BDTscore = ["bdtscoreX_LLP350_MS80_perJet"]
         jet_kinematics = ["Eta", "Phi", "Pt"]
-        bin_num = [12, 6, 6]
+        bin_num = [12, 6, 8]
         plot_x_range = [1.26, 3.2, 1]
         plot_y_range = [0.01, 0.007, 0.02]
-        bin_widths = np.array([40, 60, 80, 120, 160, 240, 400], dtype='float64') 
+        bin_widths = np.array([40, 50, 60, 70, 80, 120, 160, 240, 400], dtype='float64') 
 
         misTagJets = {}
         allJets = {}
@@ -651,7 +650,7 @@ def MisTagProbability(tree, obj_type):
                     misTagJets_6 = ROOT.TH1F("Numerator " + var, "Jet; Jet " + var + "; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
                     allJets_6 = ROOT.TH1F("Denominator "+ var, "Jet; Jet " + var + "; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
 
-                for i in number:
+                for i in jet_number:
                     hname_temp = obj_type + i + "_" + var + "_highScore"
                     hname_denom = obj_type + i + "_" + var
                     if var != "Pt":
@@ -683,7 +682,7 @@ def MisTagProbability(tree, obj_type):
                 allJets_6.SetTitle("All jets, for L1 trigger matched = " + str(trig_matched))
                 canv_individual.SaveAs(folder + "/All_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched) + ".png")
 
-                legend.AddEntry(misTagJets_6, obj_type + " " + str(len(number)-1))
+                legend.AddEntry(misTagJets_6, obj_type + " " + str(len(jet_number)-1))
                 # check efficiency on the whole distribution now
                 if(ROOT.TEfficiency.CheckConsistency(misTagJets_6, allJets_6)):
                     pEff = ROOT.TEfficiency(misTagJets_6,allJets_6)
@@ -710,16 +709,14 @@ def MisTagProbability(tree, obj_type):
 # ------------------------------------------------------------------------------
 def MisTagPrediction(tree, obj_type):
     if (obj_type == "jet"):
-        # number = ["0", "1", "2", "3", "4", "5"]
-        number = ["0"]
 
         LLP_matching = ["L1trig_Matched"] # jet + number + var = full histogram name
         LLP_BDTscore = ["bdtscoreX_LLP350_MS80_perJet"]
         jet_kinematics = ["Eta", "Phi", "Pt"]
-        bin_num = [12, 6, 6]
+        bin_num = [12, 6, 8]
         plot_x_range = [1.26, 3.2, 1]
         plot_y_range = [0.01, 0.007, 0.02]
-        bin_widths = np.array([40, 60, 80, 120, 160, 240, 400], dtype='float64') 
+        bin_widths = np.array([40, 50, 60, 70, 80, 120, 160, 240, 400], dtype='float64') 
 
         misTagJets = {}
         allJets = {}
@@ -744,14 +741,15 @@ def MisTagPrediction(tree, obj_type):
                     allJets_6_actual = ROOT.TH1F("Actual "+ var + str(trig_matched), "Predicted and Actual Mis-Tag Jets for L1 trigger matched = " + str(trig_matched) + "; Jet " + var + "; Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
                     allJets_6 = ROOT.TH1F("Predicted "+ var + str(trig_matched), "Predicted and Actual Mis-Tag Jets for L1 trigger matched = " + str(trig_matched) + "; Jet " + var + "; Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
 
-                for i in number:                    
+                for i in jet_number:  
+                    print (i)                 
                     hname_denom_actual = obj_type + i + "_" + var + "_actualData"
                     hname_denom = obj_type + i + "_" + var + "_forPrediction"
                     if var != "Pt":
                         allJets_actual[i] = ROOT.TH1F(hname_denom_actual, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
                         allJets[i] = ROOT.TH1F(hname_denom, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
                     else:
-                        allJets_actual[i] = ROOT.TH1F(hname_denom_actual, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
+                        allJets_actual[i] = ROOT.TH1F(hname_denom_actual, "Jet " + LLP_matching[0] + "; " + var + " efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
                         allJets[i] = ROOT.TH1F(hname_denom, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
 
                     selection_region = GetCut(obj_type + i + "_" + LLP_matching[0], trig_matched) # require matching trigger set or not set
@@ -780,7 +778,7 @@ def MisTagPrediction(tree, obj_type):
                     # print(MisTagEffDist.GetEfficiencyErrorLow(bin))
                     # print(MisTagEffDist.GetEfficiencyErrorUp(bin))
                     # print(MisTagEffDist.GetEfficiencyErrorLow(bin) / (MisTagEff_Num.GetBinContent(bin) / MisTagEff_Denom.GetBinContent(bin)) * allJets_6.GetBinContent(bin))
-                    allJets_6.SetBinError(bin, MisTagEffDist.GetEfficiencyErrorLow(bin) / (MisTagEff_Num.GetBinContent(bin) / MisTagEff_Denom.GetBinContent(bin)) * allJets_6.GetBinContent(bin)) # relative errors
+                    if (MisTagEff_Num.GetBinContent(bin) > 0): allJets_6.SetBinError(bin, MisTagEffDist.GetEfficiencyErrorLow(bin) / (MisTagEff_Num.GetBinContent(bin) / MisTagEff_Denom.GetBinContent(bin)) * allJets_6.GetBinContent(bin)) # relative errors
                     # wondering if should use a TGraph than a TEfficiency plot for easier manipulation... only dealing with one sided errors right now
 
                 hs.Add(allJets_6) # predicted
@@ -812,7 +810,7 @@ def main():
 
     # SignalDistribution(LLP1, LLP2, LLP3, LLP4, LLP5, LLP_names, "NoSel", infilepath, "WPlusJets")
 
-    # ProbabilityEst(infilepath)
+    ProbabilityEst(infilepath)
     BackgroundPrediction(infilepath)
 
 if __name__ == '__main__':

--- a/FakeRate/MisTagProbability.py
+++ b/FakeRate/MisTagProbability.py
@@ -205,6 +205,12 @@ def BackgroundComparison(infilepath):
     ActualMisTag(tree, "jet")
 
 # ------------------------------------------------------------------------------
+def SignalDistribution(infilepath):
+    infile = ROOT.TFile.Open( infilepath )
+    tree = infile.Get("NoSel")
+    SignalJetTagged(tree, "jet")
+    
+# ------------------------------------------------------------------------------
 def MakeSelection(variable, radius):
     # variable could be jet or LLP. If jet, account for which LLP it is matched to. If LLP, cut directly on LLP
     if (variable[0:3] == "jet"): variable = variable + "_isMatchedTo"
@@ -500,6 +506,58 @@ def Plot2D(tree, obj_type, radius):
             canvDepth.SaveAs(folder + "_" + radius + "/" + obj_type + var + "_energyProfile" + str(cut) + ".png")
             
 # ------------------------------------------------------------------------------
+def SignalJetTagged(tree, obj_type):
+    if (obj_type == "jet"):
+        number = ["0", "1", "2", "3", "4", "5"]
+        LLP_matching = ["L1trig_Matched"] # jet + number + var = full histogram name
+        LLP_BDTscore = ["bdtscoreX_LLP350_MS80_perJet"]
+
+        LLP_effs = {}
+
+        triggered = [-9999,0,1]
+
+        canv = ROOT.TCanvas()
+        legend = ROOT.TLegend(0.8,0.72,0.87,0.8)
+
+        for trig_matched in triggered:
+            Effs_num = ROOT.TH1F("Numerator ", "Jet " + LLP_matching[0] + "_" + str(trig_matched) +  " ; Tagged jet; Number of tagged jets", 6, 0, 6 ); 
+            for i in number:
+                
+                hname_temp = obj_type + i + "_matched_" + str(trig_matched)
+                LLP_effs[i] = ROOT.TH1F(hname_temp, "Jet " + LLP_matching[0] +  "_" + str(trig_matched) + "; Tagged jet; Number of tagged jets", 100, 0, 1000 ); 
+
+                selection_region = GetCut(obj_type + i + "_" + LLP_matching[0], trig_matched) # require matching trigger set or not set
+                pT_region = GetCut(obj_type + i + "_Pt", [40,1000])                         # require jet pT is over 40 GeV
+                eta_region = GetCut(obj_type + i + "_Eta", [-1.26,1.26])                    # require jet eta is in HB 
+                denom_cut = selection_region + pT_region + eta_region
+                BDTcut_region = GetCut(obj_type + i + "_" + LLP_BDTscore[0], [0.9, 1.1])
+
+                LLP_radius = obj_type + i + "_Pt" # use this as a distribution to draw, then integrate over
+                tree.Draw(LLP_radius +" >> "+hname_temp, denom_cut + BDTcut_region, "", tree.GetEntries(), 0 ) # require matching variable set + LLP pt is high enough
+
+                N_flagged = LLP_effs[i].Integral()
+                print(N_flagged)
+
+                Effs_num.SetBinContent(int(i), N_flagged)
+
+            legend.AddEntry(Effs_num, obj_type)
+            canv.cd()
+            Effs_num.Draw()
+
+            ROOT.gPad.Update()
+
+            mean_text = ROOT.TLatex()
+            mean_text.SetNDC()
+            mean_text.SetTextFont(42)
+            mean_text.SetTextSize(0.036)
+            mean_text.DrawLatex( xpos+0.5, ypos, "mean = %.2f" %(Effs_num.GetMean()))
+            mean_text.DrawLatex( xpos+0.5, ypos-0.05, "#sigma = %.2f" %(Effs_num.GetStdDev()))
+
+            LegendLabel(legend)
+            canv.SaveAs(folder + "/Tagged_" + obj_type +"_trigMatch" + str(trig_matched) + ".png")
+
+
+# ------------------------------------------------------------------------------
 # def SetupNumeratorDenominator(tree, obj_type):
 
 # ------------------------------------------------------------------------------
@@ -710,6 +768,8 @@ def main():
     infilepath = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/minituple_v3.7_LLPskim_Run2023_HADD.root"
 
     if len(sys.argv) > 1: infilepath = sys.argv[1]
+    
+    SignalDistribution("/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST.root")
 
     PlotSetup(infilepath)
     BackgroundPrediction(infilepath)

--- a/FakeRate/MisTagProbability.py
+++ b/FakeRate/MisTagProbability.py
@@ -1,0 +1,577 @@
+import ROOT
+from ROOT import Form
+from math import *
+import numpy as np
+import sys, os, argparse, time, errno
+import matplotlib.pyplot as plt
+from datetime import datetime
+
+start = time.time()
+
+debug = False
+time_debug = False
+
+# declare any variables or settings here
+data = False
+MC = False
+if sys.argv[2] == "data": data = True
+if sys.argv[2] == "MC": MC = True
+
+datetime_now = datetime.today().strftime('%Y_%m_%d')
+
+# set ROOT canvas information
+ROOT.gROOT.SetBatch(1)
+ROOT.gStyle.SetOptStat(0)
+ROOT.gStyle.SetEndErrorSize(0)
+ROOT.gStyle.SetPalette(ROOT.kCandy)
+
+stamp_text = ROOT.TLatex()
+stamp_text.SetNDC()
+stamp_text.SetTextFont(42)
+stamp_text.SetTextColor(ROOT.kBlack)
+stamp_text.SetTextSize(0.045)
+xpos = 0.13
+ypos = 0.85
+
+canv = ROOT.TCanvas("c","c",800,600)
+overlayCanv = ROOT.TCanvas("c1","c1",800,600)
+cmsLabel = "#scale[1]{#bf{CMS} }"
+if (data): 
+  cmsLabelExtra = "#scale[0.8]{#it{HCAL LLP Skim}}"
+  yearLumi = "#scale[0.85]{2023C (13.6 TeV)}"
+  folder = "./outPlots"
+if (MC): 
+  cmsLabelExtra = "#scale[0.8]{#it{2023 LLP MC}}"
+  yearLumi = "#scale[0.85]{#sqrt{s} = 13.6 TeV}"
+  folder = "./outPlots_MC"
+
+# Save output plots
+def OutputFolder(name):
+  try:
+    os.makedirs(folder + name)
+  except OSError:
+    pass 
+
+OutputFolder("")
+
+path = sys.argv[1] # pass the location of the processed ntuple as an argument 
+infile = ROOT.TFile.Open(path)
+
+# ------------------------------------------------------------------------------
+def GetTag( branch_name, branch_sel ):
+
+	tag = ""
+
+	if type(branch_sel) is int:
+		tag = branch_name + str(branch_sel)
+
+	elif type(branch_sel) is list:
+		if len(branch_sel) == 0:
+			print("WARNING <GetTag> : Entry error (length = 0). No tag included")
+		elif len(branch_sel) == 1:
+			tag = branch_name + str(branch_sel[0])
+		else:
+			if branch_sel[1] == branch_sel[0] + 1:
+				tag = branch_name + str(branch_sel[0])
+			else:
+				tag = branch_name + str(branch_sel[0]) + "-" + str(branch_sel[1]-1)
+
+		if len(branch_sel) > 2:
+			print("WARNING <GetTag> : 'branch_sel' input has more than two entries. Only using the first two!")
+
+	else: 
+		print("WARNING <GetTag> : Type Error. No tag included")
+	return tag 
+
+
+# ------------------------------------------------------------------------------
+def GetCut( branch_name, branch_sel):
+
+	selection = ""
+
+	if type(branch_sel) is int:
+		selection = branch_name + " == " + str(branch_sel) 
+
+	elif type(branch_sel) is list:
+		if len(branch_sel) == 0:
+			print("WARNING <GetCut> : Entry error (length = 0). No cut implemented")
+		elif len(branch_sel) == 1:
+			selection = branch_name + " == " + str(branch_sel[0])
+		else:
+			selection = branch_name + " >= " + str(branch_sel[0]) + " && " + branch_name + " < " + str(branch_sel[1])
+
+		if len(branch_sel) > 2:
+			print("WARNING <GetCut> : 'branch_sel' input has more than two entries. Only using the first two!")
+
+	else: 
+		print("WARNING <GetCut> : Type Error. No cut implemented")
+
+	return ROOT.TCut( selection + " " )
+
+# ------------------------------------------------------------------------------
+def GetCut_LLPmatch( variable, branch_name, branch_sel ):
+    # variable = jetx_IsMatchedTo or LLPx. branch_name = _DecayR. branch_sel = radius for LLP
+
+    # if just LLP, do below cuts
+    if (variable[0:3] == "LLP"):
+        selection = ""
+        if type(branch_sel) is int:
+            selection = variable + branch_name + " == " + str(branch_sel)
+        elif type(branch_sel) is list:
+            if len(branch_sel) == 0:
+                print("WARNING <GetCut_LLPmatch> : Entry error (length = 0). No cut implemented")
+            elif len(branch_sel) == 1:
+                selection = variable + branch_name + " == " + str(branch_sel[0])
+            elif len(branch_sel) == 2:
+                selection = variable + branch_name + " >= " + str(branch_sel[0]) + " && " + variable + branch_name + " < " + str(branch_sel[1])
+            else:
+                print("WARNING <GetCut_LLPmatch> : 'branch_sel' input has more than two entries. Only using the first two!")
+        else: 
+            print("WARNING <GetCut_LLPmatch> : Type Error. No cut implemented")
+        
+        if debug: print(selection + " in Get Cut (on LLP) ")
+        return ROOT.TCut( selection + " " )
+
+    # if jet, a bit more complicated. Which LLP does the jet in question match to? 
+    if (variable[0:3] == "jet"):
+        jet_match_selection_0 = variable + " == 0"
+        jet_match_selection_1 = variable + " == 1"
+    
+        selection_0 = ""
+        selection_1 = ""
+    
+        if type(branch_sel) is int:
+            selection_0 = "LLP0" + branch_name + " == " + str(branch_sel) + " && " + jet_match_selection_0
+            selection_1 = "LLP1" + branch_name + " == " + str(branch_sel) + " && " + jet_match_selection_1
+    
+        elif type(branch_sel) is list:
+            if len(branch_sel) == 0:
+                print("WARNING <GetCut_LLPmatch> : Entry error (length = 0). No cut implemented")
+            elif len(branch_sel) == 1:
+                selection_0 = "LLP0" + branch_name + " == " + str(branch_sel[0]) + " && " + jet_match_selection_0
+                selection_1 = "LLP1" + branch_name + " == " + str(branch_sel[0]) + " && " + jet_match_selection_1
+            elif len(branch_sel) == 2:
+                selection_0 = "LLP0" + branch_name + " >= " + str(branch_sel[0]) + " && " + "LLP0" + branch_name + " < " + str(branch_sel[1]) + " && " + jet_match_selection_0
+                selection_1 = "LLP1" + branch_name + " >= " + str(branch_sel[0]) + " && " + "LLP1" + branch_name + " < " + str(branch_sel[1]) + " && " + jet_match_selection_1
+            else:
+                print("WARNING <GetCut_LLPmatch> : 'branch_sel' input has more than two entries. Only using the first two!")    
+        else: 
+            print("WARNING <GetCut_LLPmatch> : Type Error. No cut implemented")
+        
+        if debug: print("(" + selection_0 + ") || (" + selection_1 + ")  in Get Cut (on jet) ")
+        return ROOT.TCut( "(" + selection_0 + ") || (" + selection_1 + ") " )
+
+# ------------------------------------------------------------------------------
+# select which iphi values to exclude, if this is empty, no cut is implemented 
+def ExcludedCut( branch_name, branch_sel ):
+
+    selection = ""
+
+    if type(branch_sel) is int:
+        selection = branch_name + " != " + str(branch_sel) 
+
+    elif type(branch_sel) is list:
+        if len(branch_sel) == 0:
+            print("WARNING <ExcludedCut> : Entry error (length = 0). No cut implemented")
+        elif len(branch_sel) == 1:
+            selection = branch_name + " != " + str(branch_sel[0])
+        else:
+            for exclude in branch_sel[:-1]:
+                selection += branch_name + " != " + str(exclude) + " && "
+            selection += branch_name + " != " + str(branch_sel[-1])
+
+    else: 
+        print("WARNING <ExcludedCut> : Type Error. No cut implemented")
+
+    if debug: print(selection + "  in Excluded Cut ")
+    return ROOT.TCut( selection + " " )
+
+# ------------------------------------------------------------------------------
+def PlotSetup(infilepath):
+
+    infile = ROOT.TFile.Open( infilepath )
+    tree = infile.Get("WPlusJets")
+
+    LLP_MatchingEfficiency(tree, "jet")
+
+# ------------------------------------------------------------------------------
+def MakeSelection(variable, radius):
+    # variable could be jet or LLP. If jet, account for which LLP it is matched to. If LLP, cut directly on LLP
+    if (variable[0:3] == "jet"): variable = variable + "_isMatchedTo"
+    cut_vars = "_DecayR"
+   
+    radius_preECAL  = [0, 161.6]
+    radius_ECAL     = [161.6, 183.6] # 22cm of ECAL
+    radius_depth1   = [183.6, 190.2]
+    radius_depth2   = [190.2, 214.2]
+    radius_depth3   = [214.2, 244.8]
+    radius_depth4   = [244.8, 295]
+
+    radius_all      = [0,9999]
+    radius_inHCAL   = [183.6, 295]
+    radius_depth12  = [183.6, 214.2]
+    radius_depth34  = [214.2, 295]
+
+    selection_radius = radius_all
+    if (radius == "all"):      selection_radius = radius_all
+    if (radius == "preECAL"):  selection_radius = radius_preECAL
+    if (radius == "ECAL"):     selection_radius = radius_ECAL
+    if (radius == "depth12"):  selection_radius = radius_depth12
+    if (radius == "depth34"):  selection_radius = radius_depth34
+    if (radius == "depth3"):   selection_radius = radius_depth3
+    if (radius == "depth4"):   selection_radius = radius_depth4
+    selection_region = GetCut_LLPmatch(variable, cut_vars, selection_radius)
+
+    return selection_region
+
+# ------------------------------------------------------------------------------
+def ResetRange(hist):
+    minXbin = hist.FindFirstBinAbove()
+    maxXbin = hist.FindLastBinAbove()
+
+    hist.GetXaxis().SetRange(minXbin, maxXbin)
+
+# ------------------------------------------------------------------------------
+def Normalize(hist):
+    if (hist.GetEntries() > 0): hist.Scale(1/hist.GetEntries())
+
+# ------------------------------------------------------------------------------
+def LegendLabel(legend):
+    legend.Draw()
+    stamp_text = ROOT.TLatex()
+    stamp_text.SetNDC()
+    stamp_text.SetTextFont(42)
+    stamp_text.SetTextSize(0.036)
+    stamp_text.DrawLatex( xpos, ypos, cmsLabel)
+    stamp_text.DrawLatex( xpos+0.06, ypos, cmsLabelExtra)
+    stamp_text.DrawLatex( 0.75, 0.91, yearLumi)
+
+# ------------------------------------------------------------------------------
+def Plot1D(tree, obj_type, radius):
+
+    canv = ROOT.TCanvas()
+    canvTemp = ROOT.TCanvas()
+        
+    # LLP kinematic / decay plotting
+    if (obj_type == "LLP"):
+        number = ["0", "1"]
+        kinematic_vars = ["DecayR", "DecayX", "DecayY", "DecayZ", "DecayD", "DecayT", "DecayCtau", "RechitN", "dR_b"]
+        LLP_group = [["RechitN", "DecayR"]]
+        LLP_decay = {}
+
+        for var in kinematic_vars:
+            legend = ROOT.TLegend(0.65,0.65,0.75,0.75)
+            for i in number:
+                hname_temp = obj_type + i + var
+                if (var == "DecayT" or var == "dR_b"): 
+                    if (var == "DecayT"): LLP_decay[i] = ROOT.TH1F(hname_temp, "LLP " + var +"  r=" + radius + "; " + var +" [cm]; Number of Entries", 3000, 0, 300 ); 
+                    if (var == "dR_b"): LLP_decay[i] = ROOT.TH1F(hname_temp, "#Delta R (LLP, b),  r=" + radius + "; #Delta R; Number of Entries", 100, 0, 1.6 ); 
+                else: LLP_decay[i] = ROOT.TH1F(hname_temp, "LLP " + var +", r=" + radius + "; " + var +" [cm]; Number of Entries", 3000, -3000, 3000 ); 
+
+                dist = obj_type + i + "_" + var
+                canvTemp.cd()
+                if (time_debug): print("1D LLP loop, drawing tree, with time = " + str(time.time() - start))
+                selection_region = MakeSelection(obj_type + i, radius)
+                tree.Draw(dist +" >> "+hname_temp, selection_region, "", tree.GetEntries(), 0 )
+                
+                if i == "1": 
+                    ResetRange(LLP_decay[i])
+                    legend.AddEntry(LLP_decay[i], obj_type)
+                    LLP_decay[i].Add(LLP_decay["0"])
+                    canv.cd()
+                    LLP_decay[i].Draw("HIST PLC")
+                    mean_text = ROOT.TLatex()
+                    mean_text.SetNDC()
+                    mean_text.SetTextFont(42)
+                    mean_text.SetTextSize(0.036)
+                    mean_text.DrawLatex( xpos+0.4, ypos, "mean = %.2f" %(LLP_decay[i].GetMean()))
+                    mean_text.DrawLatex( xpos+0.4, ypos-0.05, "#sigma = %.2f" %(LLP_decay[i].GetStdDev()))
+
+            LegendLabel(legend)
+            OutputFolder("_" + radius)
+            canv.SaveAs(folder + "_" + radius + "/" + obj_type + "_" +var+".png")
+
+        # LLP 2D distributions
+        LLP_dist = {}
+        for var in LLP_group:
+            for i in number:
+                legend = ROOT.TLegend(0.65,0.65,0.75,0.75)
+                xaxis = int(300)
+                hname_temp = obj_type + var[0] + i
+                LLP_dist[i] = ROOT.TH2F(hname_temp, "Jet " + i + " " + var[0] + " vs. " + var[1] + "  r=" + radius + "; " + var[1] + "; " + var[0], 100, 0, xaxis, int(100/2), 0, int(xaxis/6) ); 
+                legend.AddEntry(LLP_dist[i], obj_type + i)
+
+                dist1 = obj_type + i + "_" + var[0] 
+                dist2 = obj_type + i + "_" + var[1] 
+                canvTemp.cd()
+                selection_region = MakeSelection(obj_type + i, radius)
+                tree.Draw(dist1 + ":" + dist2 +" >> "+hname_temp, selection_region, "", tree.GetEntries(), 0 )
+                if i == "1": 
+                    LLP_dist[i].Add(LLP_dist["0"])
+                    canv.cd()
+                    LLP_dist[i].Draw("COLZ PLC")
+                    LegendLabel(legend)
+                    canv.SaveAs(folder + "_" + radius + "/" + obj_type + i + "_" +var[0]+ "_" +var[1]+ ".png")
+
+    # jet kinematic plotting 
+    if (obj_type == "jet"):
+        number = ["0", "1", "2"]
+        kinematic_vars = ["RechitN", "Eta", "Phi", "EtaSpread", "PhiSpread", "EtaSpread_energy", "PhiSpread_energy", 
+                            "E", "Pt", 
+                            "Track0Pt", "Track1Pt", "Track2Pt", 
+                            "Track0dzToPV", "Track1dzToPV", "Track2dzToPV", "Track0dxyToBS", "Track1dxyToBS", "Track2dxyToBS",
+                            "Track0dzOverErr", "Track1dzOverErr", "Track2dzOverErr", "Track0dxyOverErr", "Track1dxyOverErr", "Track2dxyOverErr",
+                            "TDCavg", "TDCavg_energyWeight", "TDCnDelayed"]
+        jet_group = [[ "PhiSpread", "EtaSpread"], ["PhiSpread_energy", "EtaSpread_energy"]]
+
+        jet_kinematic = {}
+        for var in kinematic_vars:
+            legend = ROOT.TLegend(0.65,0.65,0.8,0.8)
+            hs = ROOT.THStack("hs",  "Jet " + var +", r=" + radius + "; " + var +";Normalized Number of Entries")
+            minXbin = 0
+            maxXbin = 0
+            for i in number:
+                hname_temp = obj_type + i + var + radius
+                nBins = 600
+                x_min = -100
+                x_max = 500
+                if (var[0:3] == "Eta" or var[0:3] == "Phi"): # eta phi range
+                    nBins = 100
+                    x_min = -4
+                    x_max = 4
+                    if (var[3:9] == "Spread"):
+                        nBins = 600
+                if (var[0:5] == "Track"):
+                    nBins = 100
+                    x_min = 0
+                    x_max = 50
+                if (var[6:12] == "dzToPV" or var[6:13] == "dxyToBS" ):
+                    nBins = 80
+                    x_min = -40
+                    x_max = 40
+                    if (var[6:13] == "dxyToBS"):
+                        canv.SetLogy()
+                        x_min = -10
+                        x_max = 10
+                if (var[9:16] == "OverErr"):
+                    canv.SetLogy()
+                    x_max = 25
+                if (var[0:3] == "TDC" or var[0:12] == "energyWeight"):
+                    canv.SetLogy()
+                    nBins = 3000
+                jet_kinematic[i] = ROOT.TH1F(hname_temp, "Jet " + var +"  r=" + radius + "; " + var +"; Number of Entries", nBins, x_min, x_max ); 
+                legend.AddEntry(jet_kinematic[i], obj_type + i)
+
+                dist = obj_type + i + "_" + var
+                canvTemp.cd()
+                if (time_debug): print("1D jet loop, drawing tree, with time = " + str(time.time() - start))
+                if (MC): selection_region = MakeSelection(obj_type + i, radius)
+                else: selection_region = ""
+                tree.Draw(dist +" >> "+hname_temp, selection_region, "", tree.GetEntries(), 0 )
+                
+                Normalize(jet_kinematic[i])
+                if (jet_kinematic[i].FindFirstBinAbove() > minXbin): minXbin = jet_kinematic[i].FindFirstBinAbove()
+                if (jet_kinematic[i].FindLastBinAbove() > maxXbin): maxXbin = jet_kinematic[i].FindLastBinAbove()
+                hs.Add(jet_kinematic[i])
+
+            canv.cd()
+            hs.Draw("HIST PLC nostack")
+            hs.GetXaxis().SetRange(minXbin, maxXbin)
+            LegendLabel(legend)
+            # write mean and sigma for jet 0 to easily compare plots
+            mean_text = ROOT.TLatex()
+            mean_text.SetNDC()
+            mean_text.SetTextFont(42)
+            mean_text.SetTextSize(0.036)
+            mean_text.DrawLatex( xpos+0.4, ypos, "jet 0 mean = %.2f" %(jet_kinematic["0"].GetMean()))
+            mean_text.DrawLatex( xpos+0.4, ypos-0.05, "#sigma = %.2f" %(jet_kinematic["0"].GetStdDev()))
+            OutputFolder("_" + radius)
+            canv.SaveAs(folder + "_" + radius + "/" + obj_type + "_" +var+".png")
+
+        # jet 2D distributions
+        jet_dist = {}
+        for var in jet_group:
+            for i in number:
+                legend = ROOT.TLegend(0.65,0.65,0.75,0.75)
+                xaxis = 0.25
+                if var[0] == "EtaSpread": xaxis = 0.35
+                hname_temp = obj_type + var[0] + i
+                jet_dist[i] = ROOT.TH2F(hname_temp, "Jet " + i + " " + var[0] + " vs. " + var[1] + "  r=" + radius + "; " + var[1] + "; " + var[0], 100, 0, xaxis, 100, 0, xaxis ); 
+                legend.AddEntry(jet_dist[i], obj_type + i)
+
+                dist1 = obj_type + i + "_" + var[0] 
+                dist2 = obj_type + i + "_" + var[1] 
+                canvTemp.cd()
+                if (MC): selection_region = MakeSelection(obj_type + i, radius)
+                else: selection_region = ""
+                tree.Draw(dist1 + ":" + dist2 +" >> "+hname_temp, selection_region, "", tree.GetEntries(), 0 )
+                canv.cd()
+                jet_dist[i].Draw("COLZ PLC")
+
+                LegendLabel(legend)
+                canv.SetLogy(0) # linear                
+                canv.SaveAs(folder + "_" + radius + "/"  + obj_type + i + "_" +var[0]+ "_" +var[1]+ ".png")
+
+# ------------------------------------------------------------------------------
+def Plot2D(tree, obj_type, radius):
+
+    # LLP and jet are essentially treated the same here
+    # fraction of energy in each depth
+    number = ["0", "1", "2"]
+    kinematic_vars = ["_EnergyFrac_Depth", "_EnergyFracLLP_Depth"]
+
+    jet_et_cuts = [""]
+    if (obj_type == "jet"): jet_et_cuts = [[0,2000000], [0,200], [200,2000000]]
+
+    for cut in jet_et_cuts:
+        for var in kinematic_vars:
+            energy_profile, energy_depth_profile = {}, {}
+
+            canvTemp = ROOT.TCanvas()
+            canv = ROOT.TCanvas()
+            canvDepth = ROOT.TCanvas()
+            legend = ROOT.TLegend(0.65,0.65,0.8,0.8)
+
+            if (obj_type == "jet" and var == "_EnergyFracLLP_Depth"): continue # only have this for LLP
+            for i in number:
+                if (i == "2" and obj_type != "jet"): continue
+                hname = obj_type + var + i + "_energy_depth_profile"
+                energy_depth_profile[i] = ROOT.TH1F(hname, obj_type + " Depth Energy Profile r=" + radius + "; Depth (HB); Fraction of Energy", 6,0,6 ); 
+
+                hs = ROOT.THStack("hs",  obj_type + i + " Energy Fraction in HCAL Depths, r=" + radius + "; Fraction of HCAL Rechit Energy; Normalized Number of Entries")
+                legend_depth = ROOT.TLegend(0.65,0.65,0.8,0.8)
+                for depth in range(4):
+                    depth += 1
+                    var_type = obj_type + i + var + str(depth)
+                    hname_temp = var_type + "_energy_profile_d"+str(depth) + "_" + radius + str(cut)
+                    energy_profile[(depth,i)] = ROOT.TH1F(hname_temp, obj_type+" Depth Energy Frac in Depth "+str(depth)+ ", r=" + radius + "; Depth (HB); Fraction of Energy", 100, 0, 1 );
+
+                    canvTemp.cd()
+                    if (time_debug): print("2D loop, drawing tree, with time = " + str(time.time() - start))
+                    if (MC):
+                        selection_region = MakeSelection(obj_type + i, radius)
+                        if (obj_type == "jet"): selection_region += GetCut(obj_type + i + "_Pt", cut)  # [0, 200]
+                        if (debug): print (selection_region)
+                    else: selection_region = ""
+                    tree.Draw(var_type +" >> "+hname_temp, selection_region, "", tree.GetEntries(), 0 )
+
+                    # for LLP, combine distributions
+                    if obj_type == "LLP":
+                        if i == "0": continue
+                        if i == "1": energy_profile[(depth,i)].Add(energy_profile[(depth,"0")]) # determine averages for summed LLP1 and LLP2
+                    
+                    Normalize(energy_profile[(depth,i)])
+                    legend_depth.AddEntry(energy_profile[(depth,i)], "depth = " + str(depth))
+                    hs.Add(energy_profile[(depth,i)])
+
+                    AverageEnergyFrac = energy_profile[(depth,i)].GetMean()
+                    AverageEnergyFrac_error = energy_profile[(depth,i)].GetMeanError()
+                
+                    energy_depth_profile[i].SetBinContent(depth+1, AverageEnergyFrac)
+                    energy_depth_profile[i].SetBinError(depth+1, AverageEnergyFrac_error)
+
+                if obj_type == "LLP" and i == "0": continue
+                canv.cd()
+                canv.SetLogy()
+                hs.Draw("HIST PLC nostack")
+                LegendLabel(legend_depth)
+                canv.SaveAs(folder + "_" + radius + "/" + obj_type + i + var + "_energyFractionOverlay" + str(cut) + ".png")
+
+                # average energy fraction vs depth
+                if i == "0" and obj_type == "LLP": continue
+                canvDepth.cd()
+                legend.AddEntry(energy_depth_profile[i], obj_type + i)
+                energy_depth_profile[i].GetYaxis().SetRangeUser(0,0.7)
+                if i == "0": energy_depth_profile[i].Draw("HIST E1 PLC")
+                else: energy_depth_profile[i].Draw("SAME HIST E1 PLC")
+
+            if (time_debug): print("Plotting results, with time = " + str(time.time() - start))
+            LegendLabel(legend)
+            canvDepth.SaveAs(folder + "_" + radius + "/" + obj_type + var + "_energyProfile" + str(cut) + ".png")
+            
+# ------------------------------------------------------------------------------
+def LLP_MatchingEfficiency(tree, obj_type):
+    # for an LLP, determine efficiency for it's matching to a rechit cluster; and determine efficiency for its matching to a L1 jet
+    # plot the efficiency as a function of decay R (or other variables -- start with radius for now)
+    
+    if (obj_type == "jet"):
+        number = ["0", "1", "2", "3", "4", "5"]
+
+        LLP_matching = ["L1trig_Matched"] # jet + number + var = full histogram name
+        LLP_BDTscore = ["bdtscoreX_LLP350_MS80_perJet"]
+        LLP_denominator = ["Eta", "Phi", "Pt"]
+        bin_num = [12, 6, 6]
+        plot_range = [1.5, 3.2, 1]
+        bin_widths = np.array([40, 60, 80, 120, 160, 240, 400], dtype='float64') 
+
+        LLP_effs = {}
+        LLP_denom = {}
+
+        counter = 0
+        for var in LLP_denominator:
+            canv = ROOT.TCanvas()
+            legend = ROOT.TLegend(0.8,0.72,0.87,0.8)
+
+            if var != "Pt":
+                Effs_num = ROOT.TH1F("Numerator " + var, "Jet;" + var + " Efficiency by jet; Jet Tagging Efficiency", bin_num[counter], -plot_range[counter], plot_range[counter] ); 
+                Effs_denom = ROOT.TH1F("Denominator "+ var, "Jet;" + var + " Efficiency by jet; Jet Tagging Efficiency", bin_num[counter], -plot_range[counter], plot_range[counter] ); 
+            else:
+                Effs_num = ROOT.TH1F("Numerator " + var, "Jet;" + var + " Efficiency by jet; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
+                Effs_denom = ROOT.TH1F("Denominator "+ var, "Jet;" + var + " Efficiency by jet; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
+
+            for i in number:
+                # require that jet is over pT to be included in denominator
+                
+                # require that jet is not triggered to be in numerator, and over a set BDT score
+
+                hname_temp = obj_type + i + "_" + var + "_matched"
+                hname_denom = obj_type + i + "_" + var
+                if var != "Pt":
+                    LLP_effs[i] = ROOT.TH1F(hname_temp, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Jet Tagging Efficiency", bin_num[counter], -plot_range[counter], plot_range[counter] ); 
+                    LLP_denom[i] = ROOT.TH1F(hname_denom, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Jet Tagging Efficiency", bin_num[counter], -plot_range[counter], plot_range[counter] ); 
+                else:
+                    LLP_effs[i] = ROOT.TH1F(hname_temp, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
+                    LLP_denom[i] = ROOT.TH1F(hname_denom, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
+
+                selection_region = ExcludedCut(obj_type + i + "_" + LLP_matching[0], 1)          # require matching trigger not set
+                BDTcut_region = GetCut(obj_type + i + "_" + LLP_BDTscore[0], [0.9, 1.1])
+                pT_region = GetCut(obj_type + i + "_Pt", [40,1000])            # require jet pT is over 40 GeV
+                eta_region = GetCut(obj_type + i + "_Eta", [-1.26,1.26])       # require jet eta is in HB 
+                total_cut = selection_region + BDTcut_region + pT_region + eta_region
+
+                LLP_radius = obj_type + i + "_" + var
+                tree.Draw(LLP_radius +" >> "+hname_temp, total_cut, "", tree.GetEntries(), 0 ) # require matching variable set + LLP pt is high enough
+                tree.Draw(LLP_radius +" >> "+hname_denom, pT_region + eta_region, "", tree.GetEntries(), 0 ) # require LLP pt is high enough and in HB
+                
+                Effs_num.Add(LLP_effs[i])
+                Effs_denom.Add(LLP_denom[i])
+
+            counter += 1
+            # ResetRange(Effs_num)
+            legend.AddEntry(Effs_num, obj_type)
+            # check efficiency on the whole distribution now
+            if(ROOT.TEfficiency.CheckConsistency(Effs_num, Effs_denom)):
+                pEff = ROOT.TEfficiency(Effs_num,Effs_denom)
+                canv.cd()
+                pEff.Draw()
+                mean_text = ROOT.TLatex()
+                mean_text.SetNDC()
+                mean_text.SetTextFont(42)
+                mean_text.SetTextSize(0.036)
+                mean_text.DrawLatex( xpos+0.5, ypos, "mean = %.2f" %(Effs_num.GetMean()))
+                mean_text.DrawLatex( xpos+0.5, ypos-0.05, "#sigma = %.2f" %(Effs_num.GetStdDev()))
+
+                LegendLabel(legend)
+                canv.SaveAs(folder + "/Efficiency_" + obj_type + "_" +var+".png")
+
+# ------------------------------------------------------------------------------
+def main():
+
+	infilepath = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/minituple_v3.7_LLPskim_Run2023_HADD.root"
+
+	if len(sys.argv) > 1: infilepath = sys.argv[1]
+
+	PlotSetup(infilepath)
+
+if __name__ == '__main__':
+	main()

--- a/FakeRate/MisTagProbability.py
+++ b/FakeRate/MisTagProbability.py
@@ -634,8 +634,9 @@ def MisTagProbability(tree, obj_type):
 
         triggered = [-9999,0,1]
 
-        frac_track_pt_bins = [[0, 1.1], [0, 0.5], [0.5, 1.1]]
-        label_track_pt_bins = ["inclusive", "<0.5", ">=0.5"]
+        frac_track_pt_bins = [[0, 0.5], [0.5, 1.1], [0, 1.1]]
+        ele_frac_bins = [[0, 0.5], [0.5, 1.1], [0, 1.1]]
+        label_track_pt_bins = ["<0.5", ">=0.5", "inclusive"]
 
         outfile = ROOT.TFile.Open("outfile.root", "RECREATE")
 
@@ -669,7 +670,9 @@ def MisTagProbability(tree, obj_type):
                         pT_region = GetCut(obj_type + i + "_Pt", [40,1000])                         # require jet pT is over 40 GeV
                         eta_region = GetCut(obj_type + i + "_Eta", [-1.26,1.26])                    # require jet eta is in HB 
                         track_region = GetCut("(" + obj_type + i + "_Track0Pt / " + obj_type + i + "_Pt)", track_pt)    # split estimation in different track pT bins
-                        denom_cut = selection_region + pT_region + eta_region + track_region
+                        ele_region = GetCut(obj_type + i + "_EleEFrac", ele_frac_bins[track_counter])    # split estimation in different jet electron energy fraction (low with low track pT, high with high, inclusive together)
+
+                        denom_cut = selection_region + pT_region + eta_region + track_region + ele_region
                         BDTcut_region = GetCut(obj_type + i + "_" + LLP_BDTscore[0], [0.9, 1.1])
 
                         Jet_plots = obj_type + i + "_" + var
@@ -734,6 +737,7 @@ def MisTagPrediction(tree, obj_type):
         triggered = [-9999] # [1, 0, -9999]
 
         frac_track_pt_bins = [[0, 0.5], [0.5, 1.1], [0, 1.1]]
+        ele_frac_bins = [[0, 0.5], [0.5, 1.1], [0, 1.1]]
         label_track_pt_bins = ["<0.5", ">=0.5", "inclusive"]
 
         mistag_file = ROOT.TFile.Open("outfile.root")
@@ -770,9 +774,10 @@ def MisTagPrediction(tree, obj_type):
                         pT_region = GetCut(obj_type + i + "_Pt", [40,1000])                         # require jet pT is over 40 GeV
                         eta_region = GetCut(obj_type + i + "_Eta", [-1.26,1.26])                    # require jet eta is in HB 
                         track_region = GetCut("(" + obj_type + i + "_Track0Pt / " + obj_type + i + "_Pt)", track_pt)    # split estimation in different track pT bins
+                        ele_region = GetCut(obj_type + i + "_EleEFrac", ele_frac_bins[track_counter])    # split estimation in different jet electron energy fraction (low with low track pT, high with high, inclusive together)
 
                         BDTcut_region = GetCut(obj_type + i + "_" + LLP_BDTscore[0], [0.9, 1.1])
-                        denom_cut = selection_region + pT_region + eta_region + track_region
+                        denom_cut = selection_region + pT_region + eta_region + track_region + ele_region
 
                         Jet_plots = obj_type + i + "_" + var
                         tree.Draw(Jet_plots +" >> "+hname_denom, denom_cut, "", tree.GetEntries(), 0 ) # require LLP pt is high enough and in HB

--- a/FakeRate/MisTagProbability.py
+++ b/FakeRate/MisTagProbability.py
@@ -570,9 +570,9 @@ def SignalJetTagged(tree1, tree2, tree3, tree4, tree5, signal_names, tree_bkg, o
 
                 for name in signal_names: 
                     TagJets[name].SetBinContent(int(i)+1, N_flagged[name]) # remember to fill first bin (not 0!)
-                    if (N_flagged[name] > 0): TagJets[name].SetBinError(int(i)+1, sqrt(1/N_flagged[name]))
+                    if (N_flagged[name] > 0): TagJets[name].SetBinError(int(i)+1, sqrt(N_flagged[name]))
                 TagJets_bkg.SetBinContent(int(i)+1, N_flagged_bkg)
-                if (N_flagged_bkg > 0): TagJets_bkg.SetBinError(int(i)+1, sqrt(1/N_flagged_bkg))
+                if (N_flagged_bkg > 0): TagJets_bkg.SetBinError(int(i)+1, sqrt(N_flagged_bkg))
 
             for name in signal_names: 
                 TagJets[name].Scale(1/N_tot[name]) # fraction, not number

--- a/FakeRate/MisTagProbability.py
+++ b/FakeRate/MisTagProbability.py
@@ -624,174 +624,192 @@ def MisTagProbability(tree, obj_type):
         LLP_matching = ["L1trig_Matched"] # jet + number + var = full histogram name
         LLP_BDTscore = ["bdtscoreX_LLP350_MS80_perJet"]
         jet_kinematics = ["Eta", "Phi", "Pt"]
-        bin_num = [12, 6, 8]
+        bin_num = [12, 6, 9]
         plot_x_range = [1.26, 3.2, 1]
         plot_y_range = [0.01, 0.007, 0.02]
-        bin_widths = np.array([40, 50, 60, 70, 80, 120, 160, 240, 400], dtype='float64') 
+        bin_widths = np.array([40, 50, 60, 70, 80, 100, 120, 160, 240, 400], dtype='float64') 
 
         misTagJets = {}
         allJets = {}
 
         triggered = [-9999,0,1]
 
+        frac_track_pt_bins = [[0, 1.1], [0, 0.5], [0.5, 1.1]]
+        label_track_pt_bins = ["inclusive", "<0.5", ">=0.5"]
+
         outfile = ROOT.TFile.Open("outfile.root", "RECREATE")
 
         for trig_matched in triggered:
-            counter = 0
-            for var in jet_kinematics:
-                canv = ROOT.TCanvas()
-                canv_individual = ROOT.TCanvas()
-                legend = ROOT.TLegend(0.8,0.72,0.87,0.8)
+            track_counter = 0
+            for track_pt in frac_track_pt_bins:
+                counter = 0
+                for var in jet_kinematics:
+                    canv = ROOT.TCanvas()
+                    canv_individual = ROOT.TCanvas()
+                    legend = ROOT.TLegend(0.8,0.72,0.87,0.8)
 
-                if var != "Pt":
-                    misTagJets_6 = ROOT.TH1F("Numerator " + var, "Jet; Jet " + var + "; Jet Tagging Efficiency", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
-                    allJets_6 = ROOT.TH1F("Denominator "+ var, "Jet; Jet " + var + "; Jet Tagging Efficiency", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
-                else:
-                    misTagJets_6 = ROOT.TH1F("Numerator " + var, "Jet; Jet " + var + "; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
-                    allJets_6 = ROOT.TH1F("Denominator "+ var, "Jet; Jet " + var + "; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
-
-                for i in jet_number:
-                    hname_temp = obj_type + i + "_" + var + "_highScore"
-                    hname_denom = obj_type + i + "_" + var
                     if var != "Pt":
-                        misTagJets[i] = ROOT.TH1F(hname_temp, "Jet " + LLP_matching[0] + "; " + var +"; Jet Tagging Efficiency", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
-                        allJets[i] = ROOT.TH1F(hname_denom, "Jet " + LLP_matching[0] + "; " + var +"; Jet Tagging Efficiency", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
+                        misTagJets_6 = ROOT.TH1F("Numerator " + var, "Jet; Jet " + var + "; Jet Tagging Efficiency", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
+                        allJets_6 = ROOT.TH1F("Denominator "+ var, "Jet; Jet " + var + "; Jet Tagging Efficiency", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
                     else:
-                        misTagJets[i] = ROOT.TH1F(hname_temp, "Jet " + LLP_matching[0] + "; " + var +"; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
-                        allJets[i] = ROOT.TH1F(hname_denom, "Jet " + LLP_matching[0] + "; " + var +"; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
+                        misTagJets_6 = ROOT.TH1F("Numerator " + var, "Jet; Jet " + var + "; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
+                        allJets_6 = ROOT.TH1F("Denominator "+ var, "Jet; Jet " + var + "; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
 
-                    selection_region = GetCut(obj_type + i + "_" + LLP_matching[0], trig_matched) # require matching trigger set or not set
-                    pT_region = GetCut(obj_type + i + "_Pt", [40,1000])                         # require jet pT is over 40 GeV
-                    eta_region = GetCut(obj_type + i + "_Eta", [-1.26,1.26])                    # require jet eta is in HB 
-                    denom_cut = selection_region + pT_region + eta_region
-                    BDTcut_region = GetCut(obj_type + i + "_" + LLP_BDTscore[0], [0.9, 1.1])
+                    for i in jet_number:
+                        hname_temp = obj_type + i + "_" + var + "_highScore"
+                        hname_denom = obj_type + i + "_" + var
+                        if var != "Pt":
+                            misTagJets[i] = ROOT.TH1F(hname_temp, "Jet " + LLP_matching[0] + "; " + var +"; Jet Tagging Efficiency", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
+                            allJets[i] = ROOT.TH1F(hname_denom, "Jet " + LLP_matching[0] + "; " + var +"; Jet Tagging Efficiency", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
+                        else:
+                            misTagJets[i] = ROOT.TH1F(hname_temp, "Jet " + LLP_matching[0] + "; " + var +"; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
+                            allJets[i] = ROOT.TH1F(hname_denom, "Jet " + LLP_matching[0] + "; " + var +"; Jet Tagging Efficiency", bin_num[counter], bin_widths ); 
 
-                    LLP_radius = obj_type + i + "_" + var
-                    tree.Draw(LLP_radius +" >> "+hname_temp, denom_cut + BDTcut_region, "", tree.GetEntries(), 0 ) # require matching variable set + LLP pt is high enough
-                    tree.Draw(LLP_radius +" >> "+hname_denom, denom_cut, "", tree.GetEntries(), 0 ) # require LLP pt is high enough and in HB
-                    
-                    misTagJets_6.Add(misTagJets[i])
-                    allJets_6.Add(allJets[i])
+                        selection_region = GetCut(obj_type + i + "_" + LLP_matching[0], trig_matched) # require matching trigger set or not set
+                        pT_region = GetCut(obj_type + i + "_Pt", [40,1000])                         # require jet pT is over 40 GeV
+                        eta_region = GetCut(obj_type + i + "_Eta", [-1.26,1.26])                    # require jet eta is in HB 
+                        track_region = GetCut("(" + obj_type + i + "_Track0Pt / " + obj_type + i + "_Pt)", track_pt)    # split estimation in different track pT bins
+                        denom_cut = selection_region + pT_region + eta_region + track_region
+                        BDTcut_region = GetCut(obj_type + i + "_" + LLP_BDTscore[0], [0.9, 1.1])
 
-                canv_individual.cd()
-                misTagJets_6.Draw()
-                misTagJets_6.SetTitle("Mis-tagged jets, for L1 trigger matched = " + str(trig_matched))
-                canv_individual.SaveAs(folder + "/MisTag_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched) + ".png")
-                canv_individual.Clear()
-                allJets_6.Draw()
-                allJets_6.SetTitle("All jets, for L1 trigger matched = " + str(trig_matched))
-                canv_individual.SaveAs(folder + "/All_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched) + ".png")
+                        Jet_plots = obj_type + i + "_" + var
+                        tree.Draw(Jet_plots +" >> "+hname_temp, denom_cut + BDTcut_region, "", tree.GetEntries(), 0 ) # require matching variable set + LLP pt is high enough
+                        tree.Draw(Jet_plots +" >> "+hname_denom, denom_cut, "", tree.GetEntries(), 0 ) # require LLP pt is high enough and in HB
+                        
+                        misTagJets_6.Add(misTagJets[i])
+                        allJets_6.Add(allJets[i])
 
-                legend.AddEntry(misTagJets_6, obj_type + " " + str(len(jet_number)-1))
-                # check efficiency on the whole distribution now
-                if(ROOT.TEfficiency.CheckConsistency(misTagJets_6, allJets_6)):
-                    pEff = ROOT.TEfficiency(misTagJets_6,allJets_6)
-                    canv.cd()
-                    pEff.Draw()
+                    canv_individual.cd()
+                    misTagJets_6.Draw()
+                    misTagJets_6.SetTitle("Mis-tagged jets, for L1 trigger matched = " + str(trig_matched) + ", with track " + label_track_pt_bins[track_counter])
+                    canv_individual.SaveAs(folder + "/MisTag_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched) + "_track_" + label_track_pt_bins[track_counter] + ".png")
+                    canv_individual.Clear()
+                    allJets_6.Draw()
+                    allJets_6.SetTitle("All jets, for L1 trigger matched = " + str(trig_matched) + ", with track " + label_track_pt_bins[track_counter])
+                    canv_individual.SaveAs(folder + "/All_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched) + "_track_" + label_track_pt_bins[track_counter] + ".png")
 
-                    ROOT.gPad.Update()
-                    pEff.GetPaintedGraph().GetYaxis().SetRangeUser(0, plot_y_range[counter])
-                    pEff.SetTitle("Mis-Tag Probability for L1 trigger matched = " + str(trig_matched))
+                    legend.AddEntry(misTagJets_6, obj_type + " " + str(len(jet_number)-1))
+                    # check efficiency on the whole distribution now
+                    if(ROOT.TEfficiency.CheckConsistency(misTagJets_6, allJets_6)):
+                        pEff = ROOT.TEfficiency(misTagJets_6,allJets_6)
+                        canv.cd()
+                        pEff.Draw()
 
-                    mean_text = ROOT.TLatex()
-                    mean_text.SetNDC()
-                    mean_text.SetTextFont(42)
-                    mean_text.SetTextSize(0.036)
-                    mean_text.DrawLatex( xpos+0.5, ypos, "mean = %.2f" %(misTagJets_6.GetMean()))
-                    mean_text.DrawLatex( xpos+0.5, ypos-0.05, "#sigma = %.2f" %(misTagJets_6.GetStdDev()))
+                        ROOT.gPad.Update()
+                        pEff.GetPaintedGraph().GetYaxis().SetRangeUser(0, plot_y_range[counter])
+                        pEff.SetTitle("Mis-Tag Probability for L1 trigger matched = " + str(trig_matched) + ", with track " + label_track_pt_bins[track_counter])
 
-                    LegendLabel(legend)
-                    canv.SaveAs(folder + "/Efficiency_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched) + ".png")
-                    outfile.WriteObject(pEff, "Efficiency_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched))
-                counter += 1
+                        mean_text = ROOT.TLatex()
+                        mean_text.SetNDC()
+                        mean_text.SetTextFont(42)
+                        mean_text.SetTextSize(0.036)
+                        mean_text.DrawLatex( xpos+0.5, ypos, "mean = %.2f" %(misTagJets_6.GetMean()))
+                        mean_text.DrawLatex( xpos+0.5, ypos-0.05, "#sigma = %.2f" %(misTagJets_6.GetStdDev()))
+
+                        LegendLabel(legend)
+                        canv.SaveAs(folder + "/Efficiency_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched) + "_track_" + label_track_pt_bins[track_counter] + ".png")
+                        outfile.WriteObject(pEff, "Efficiency_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched) + "_track" + label_track_pt_bins[track_counter])
+                    counter += 1
+                track_counter += 1
+
         outfile.Close()
 
 # ------------------------------------------------------------------------------
 def MisTagPrediction(tree, obj_type):
+    
     if (obj_type == "jet"):
 
         LLP_matching = ["L1trig_Matched"] # jet + number + var = full histogram name
         LLP_BDTscore = ["bdtscoreX_LLP350_MS80_perJet"]
         jet_kinematics = ["Eta", "Phi", "Pt"]
-        bin_num = [12, 6, 8]
+        bin_num = [12, 6, 9]
         plot_x_range = [1.26, 3.2, 1]
         plot_y_range = [0.01, 0.007, 0.02]
-        bin_widths = np.array([40, 50, 60, 70, 80, 120, 160, 240, 400], dtype='float64') 
+        bin_widths = np.array([40, 50, 60, 70, 80, 100, 120, 160, 240, 400], dtype='float64') 
 
         misTagJets = {}
         allJets = {}
         allJets_actual = {}
 
-        triggered = [1, 0, -9999]
+        triggered = [-9999] # [1, 0, -9999]
+
+        frac_track_pt_bins = [[0, 0.5], [0.5, 1.1], [0, 1.1]]
+        label_track_pt_bins = ["<0.5", ">=0.5", "inclusive"]
 
         mistag_file = ROOT.TFile.Open("outfile.root")
 
         for trig_matched in triggered:
-            counter = 0
-            for var in jet_kinematics:
-                canv = ROOT.TCanvas()
-                canv1 = ROOT.TCanvas()
-                legend = ROOT.TLegend(0.7,0.65,0.87,0.8)
+            track_counter = 0
+            for track_pt in frac_track_pt_bins:
+                counter = 0
+                for var in jet_kinematics:
+                    canv = ROOT.TCanvas()
+                    canv1 = ROOT.TCanvas()
+                    legend = ROOT.TLegend(0.7,0.65,0.87,0.8)
 
-                hs = ROOT.THStack( "hs_temp", "Predicted and Actual Mis-Tag Jets for L1 trigger matched = " + str(trig_matched) + "; Jet " + var + "; Number of Mis-tagged Jets ")
-                if var != "Pt":
-                    allJets_6_actual = ROOT.TH1F("Actual "+ var + str(trig_matched), "Predicted and Actual Mis-Tag Jets for L1 trigger matched = " + str(trig_matched) + "; Jet " + var + "; Number of Mis-tagged Jets", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
-                    allJets_6 = ROOT.TH1F("Predicted "+ var + str(trig_matched), "Predicted and Actual Mis-Tag Jets for L1 trigger matched = " + str(trig_matched) + "; Jet " + var + "; Number of Mis-tagged Jets", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
-                else:
-                    allJets_6_actual = ROOT.TH1F("Actual "+ var + str(trig_matched), "Predicted and Actual Mis-Tag Jets for L1 trigger matched = " + str(trig_matched) + "; Jet " + var + "; Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
-                    allJets_6 = ROOT.TH1F("Predicted "+ var + str(trig_matched), "Predicted and Actual Mis-Tag Jets for L1 trigger matched = " + str(trig_matched) + "; Jet " + var + "; Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
-
-                for i in jet_number:  
-                    print (i)                 
-                    hname_denom_actual = obj_type + i + "_" + var + "_actualData"
-                    hname_denom = obj_type + i + "_" + var + "_forPrediction"
+                    hs = ROOT.THStack( "hs_temp", "Predicted and Actual Mis-Tag Jets for L1 trigger matched = " + str(trig_matched) + ", with frac. track pT " + label_track_pt_bins[track_counter] + "; Jet " + var + "; Number of Mis-tagged Jets ")
                     if var != "Pt":
-                        allJets_actual[i] = ROOT.TH1F(hname_denom_actual, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
-                        allJets[i] = ROOT.TH1F(hname_denom, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
+                        allJets_6_actual = ROOT.TH1F("Actual "+ var + str(trig_matched) + ", with frac. track pT " + label_track_pt_bins[track_counter], "Predicted and Actual Mis-Tag Jets for L1 trigger matched = " + str(trig_matched) + ", with frac. track pT " + label_track_pt_bins[track_counter] + "; Jet " + var + "; Number of Mis-tagged Jets", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
+                        allJets_6 = ROOT.TH1F("Predicted "+ var + str(trig_matched) + ", with frac. track pT " + label_track_pt_bins[track_counter], "Predicted and Actual Mis-Tag Jets for L1 trigger matched = " + str(trig_matched) + ", with frac. track pT " + label_track_pt_bins[track_counter] + "; Jet " + var + "; Number of Mis-tagged Jets", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
                     else:
-                        allJets_actual[i] = ROOT.TH1F(hname_denom_actual, "Jet " + LLP_matching[0] + "; " + var + " efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
-                        allJets[i] = ROOT.TH1F(hname_denom, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
+                        allJets_6_actual = ROOT.TH1F("Actual "+ var + str(trig_matched) + ", with frac. track pT " + label_track_pt_bins[track_counter], "Predicted and Actual Mis-Tag Jets for L1 trigger matched = " + str(trig_matched) + ", with frac. track pT " + label_track_pt_bins[track_counter] + "; Jet " + var + "; Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
+                        allJets_6 = ROOT.TH1F("Predicted "+ var + str(trig_matched) + ", with frac. track pT " + label_track_pt_bins[track_counter], "Predicted and Actual Mis-Tag Jets for L1 trigger matched = " + str(trig_matched) + ", with frac. track pT " + label_track_pt_bins[track_counter] + "; Jet " + var + "; Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
 
-                    selection_region = GetCut(obj_type + i + "_" + LLP_matching[0], trig_matched) # require matching trigger set or not set
-                    pT_region = GetCut(obj_type + i + "_Pt", [40,1000])                         # require jet pT is over 40 GeV
-                    eta_region = GetCut(obj_type + i + "_Eta", [-1.26,1.26])                    # require jet eta is in HB 
-                    BDTcut_region = GetCut(obj_type + i + "_" + LLP_BDTscore[0], [0.9, 1.1])
-                    denom_cut = selection_region + pT_region + eta_region
+                    for i in jet_number:  
+                        print (i)                 
+                        hname_denom_actual = obj_type + i + "_" + var + "_actualData"
+                        hname_denom = obj_type + i + "_" + var + "_forPrediction"
+                        if var != "Pt":
+                            allJets_actual[i] = ROOT.TH1F(hname_denom_actual, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
+                            allJets[i] = ROOT.TH1F(hname_denom, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], -plot_x_range[counter], plot_x_range[counter] ); 
+                        else:
+                            allJets_actual[i] = ROOT.TH1F(hname_denom_actual, "Jet " + LLP_matching[0] + "; " + var + " efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
+                            allJets[i] = ROOT.TH1F(hname_denom, "Jet " + LLP_matching[0] + "; " + var +" efficiency by jet; Predicted and Actual Number of Mis-tagged Jets", bin_num[counter], bin_widths ); 
 
-                    LLP_radius = obj_type + i + "_" + var
-                    tree.Draw(LLP_radius +" >> "+hname_denom, denom_cut, "", tree.GetEntries(), 0 ) # require LLP pt is high enough and in HB
-                    tree.Draw(LLP_radius +" >> "+hname_denom_actual, denom_cut + BDTcut_region, "", tree.GetEntries(), 0 ) # require LLP pt is high enough and in HB
-                    
-                    allJets_6_actual.Add(allJets_actual[i])
-                    allJets_6.Add(allJets[i])
+                        selection_region = GetCut(obj_type + i + "_" + LLP_matching[0], trig_matched) # require matching trigger set or not set
+                        pT_region = GetCut(obj_type + i + "_Pt", [40,1000])                         # require jet pT is over 40 GeV
+                        eta_region = GetCut(obj_type + i + "_Eta", [-1.26,1.26])                    # require jet eta is in HB 
+                        track_region = GetCut("(" + obj_type + i + "_Track0Pt / " + obj_type + i + "_Pt)", track_pt)    # split estimation in different track pT bins
 
-                canv.cd()
-                #ROOT.gStyle.SetPalette(ROOT.kOcean)
-                MisTagEffDist = mistag_file.Get("Efficiency_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched))  
-                MisTagEff_Denom = MisTagEffDist.GetCopyTotalHisto() # need to get a TH1 from TEff object
-                MisTagEff_Num = MisTagEffDist.GetCopyPassedHisto() # need to get a TH1 from TEff object
-                allJets_6.Multiply(MisTagEff_Num)
-                allJets_6.Divide(MisTagEff_Denom) # confirmed that actual and predicted on W+jets (redundant) gives same answer
-                # handle error propagation
-                for bin in range(bin_num[counter]+1):
-                    if bin == 0: continue
-                    # print(MisTagEffDist.GetEfficiencyErrorLow(bin))
-                    # print(MisTagEffDist.GetEfficiencyErrorUp(bin))
-                    # print(MisTagEffDist.GetEfficiencyErrorLow(bin) / (MisTagEff_Num.GetBinContent(bin) / MisTagEff_Denom.GetBinContent(bin)) * allJets_6.GetBinContent(bin))
-                    if (MisTagEff_Num.GetBinContent(bin) > 0): allJets_6.SetBinError(bin, MisTagEffDist.GetEfficiencyErrorLow(bin) / (MisTagEff_Num.GetBinContent(bin) / MisTagEff_Denom.GetBinContent(bin)) * allJets_6.GetBinContent(bin)) # relative errors
-                    # wondering if should use a TGraph than a TEfficiency plot for easier manipulation... only dealing with one sided errors right now
+                        BDTcut_region = GetCut(obj_type + i + "_" + LLP_BDTscore[0], [0.9, 1.1])
+                        denom_cut = selection_region + pT_region + eta_region + track_region
 
-                hs.Add(allJets_6) # predicted
-                legend.AddEntry(allJets_6, "Predicted Mis-tag")
-                hs.Add(allJets_6_actual)
-                legend.AddEntry(allJets_6_actual, "Actual Mis-tag")
-                allJets_6_actual.SetFillStyle(3004) # to keep consistent, data is filled, MC or predictions are lines # but THstack doesn't use different fill styles :( 
-                allJets_6.SetFillStyle(0)
-                hs.Draw("HIST NOSTACK PLC PFC E1")
-                LegendLabel(legend)
-                canv.SaveAs(folder + "/PredictedMisTag_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched) + ".png")
+                        Jet_plots = obj_type + i + "_" + var
+                        tree.Draw(Jet_plots +" >> "+hname_denom, denom_cut, "", tree.GetEntries(), 0 ) # require LLP pt is high enough and in HB
+                        tree.Draw(Jet_plots +" >> "+hname_denom_actual, denom_cut + BDTcut_region, "", tree.GetEntries(), 0 ) # require LLP pt is high enough and in HB
+                        
+                        allJets_6_actual.Add(allJets_actual[i])
+                        allJets_6.Add(allJets[i])
+
+                    canv.cd()
+                    #ROOT.gStyle.SetPalette(ROOT.kOcean)
+                    MisTagEffDist = mistag_file.Get("Efficiency_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched) + "_track" + label_track_pt_bins[track_counter])  
+                    MisTagEff_Denom = MisTagEffDist.GetCopyTotalHisto() # need to get a TH1 from TEff object
+                    MisTagEff_Num = MisTagEffDist.GetCopyPassedHisto() # need to get a TH1 from TEff object
+                    allJets_6.Multiply(MisTagEff_Num)
+                    allJets_6.Divide(MisTagEff_Denom) # confirmed that actual and predicted on W+jets (redundant) gives same answer
+                    # handle error propagation
+                    for bin in range(bin_num[counter]+1):
+                        if bin == 0: continue
+                        # print(MisTagEffDist.GetEfficiencyErrorLow(bin))
+                        # print(MisTagEffDist.GetEfficiencyErrorUp(bin))
+                        # print(MisTagEffDist.GetEfficiencyErrorLow(bin) / (MisTagEff_Num.GetBinContent(bin) / MisTagEff_Denom.GetBinContent(bin)) * allJets_6.GetBinContent(bin))
+                        if (MisTagEff_Num.GetBinContent(bin) > 0): allJets_6.SetBinError(bin, MisTagEffDist.GetEfficiencyErrorLow(bin) / (MisTagEff_Num.GetBinContent(bin) / MisTagEff_Denom.GetBinContent(bin)) * allJets_6.GetBinContent(bin)) # relative errors
+                        # wondering if should use a TGraph than a TEfficiency plot for easier manipulation... only dealing with one sided errors right now
+
+                    hs.Add(allJets_6) # predicted
+                    legend.AddEntry(allJets_6, "Predicted Mis-tag")
+                    hs.Add(allJets_6_actual)
+                    legend.AddEntry(allJets_6_actual, "Actual Mis-tag")
+                    allJets_6_actual.SetFillStyle(3004) # to keep consistent, data is filled, MC or predictions are lines # but THstack doesn't use different fill styles :( 
+                    allJets_6.SetFillStyle(0)
+                    hs.Draw("HIST NOSTACK PLC PFC E1")
+                    LegendLabel(legend)
+                    canv.SaveAs(folder + "/PredictedMisTag_" + obj_type + "_" +var+"_trigMatch" + str(trig_matched) + "_track_" + label_track_pt_bins[track_counter] + ".png")
+
+                    counter += 1
                 
-                counter += 1
+                track_counter += 1
 
 # ------------------------------------------------------------------------------
 def main():

--- a/FakeRate/ReadMe.md
+++ b/FakeRate/ReadMe.md
@@ -1,0 +1,8 @@
+# Running
+
+```
+python3 MisTagProbability.py /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/minituple_v3.7_LLPskim_Run2023_HADD.root data
+```
+
+-9999 means not matched to a L1 jet, 0 means matched with LLP flag not set, 1 means matched with LLP flag set.
+

--- a/FakeRate/ReadMe.md
+++ b/FakeRate/ReadMe.md
@@ -1,8 +1,11 @@
 # Running
 
 ```
-python3 MisTagProbability.py /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/minituple_v3.7_LLPskim_Run2023_HADD.root data
+python3 MisTagProbability.py
 ```
 
 -9999 means not matched to a L1 jet, 0 means matched with LLP flag not set, 1 means matched with LLP flag set.
 
+Split by fractional track pT and jet electron energy fraction. 
+
+TODO: lots of duplicated code between prediction and measurement, need to clean this up! 

--- a/MiniTuplePlotter/Gillian/MiniTuplePlotter_CR_SR.C
+++ b/MiniTuplePlotter/Gillian/MiniTuplePlotter_CR_SR.C
@@ -24,10 +24,11 @@ void MiniTuplePlotter_CR_SR(){
 	filetags["LLP250"]		= { "v3.7_LLPskim_Run2023Cv4_2024_03_14", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_03_14_batch2"};
 	filetags["LLP350"]		= { "v3.7_LLPskim_Run2023Cv4_2024_03_14", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_03_14_batch2"};
 
-	vector<string> filetags_data 		= { "v3.7_LLPskim_Run2023Cv4_2024_03_14" };
+	vector<string> filetags_data 		= { "v3.7_LLPskim_Run2023_HADD" };
 	vector<string> filetags_LLP 		= { "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST" };	
 	vector<string> filetags_all 		= { "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_03_14_batch2", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_03_14_batch2", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_03_14_batch2"};
 
+	vector<string> BDT_files 			= {"v3.7_LLPskim_Run2023_HADD", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST"};
 	vector<string> filetags_all_v3pt0 	= { "v3.0_LLPskim_Run2023Bv1_2023Cv2_2023_11_23", "v2.0_MC_QCD_250k_2023_10_18", "v3.0_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2023_11_23"};
 	vector<string> filetags_QCD 		= { "v2.0_MC_QCD_250k_2023_10_18" };	
 
@@ -87,9 +88,9 @@ void MiniTuplePlotter_CR_SR(){
 	#include "../RegionCuts.h"
 
 	bool LLP_WJets = false;				// analysis variables for LLP and W+Jets overlayed
-	bool track_dR_study = false;			// track vars with diff dR cuts, dR with diff track cuts
+	bool track_dR_study = false;		// track vars with diff dR cuts, dR with diff track cuts
 	bool overlay_LLP = false;			// overlay analysis variables for each LLP mass point
-	bool Bkg_est = false;				// look at jet tagging vars by jet eta for probability estimations
+	bool Bkg_est = true;				// look at jet tagging vars by jet eta for probability estimations
 
 	bool LLP_all = false;				// all variables, track vars with leading track < 4 study, eta-phi spread
 	bool Jet_vars = false; 				// jet kinematics without a pT cut
@@ -97,8 +98,8 @@ void MiniTuplePlotter_CR_SR(){
 	bool Jet_bins = false;				// bin in jet pT
 	bool BDT_bins = false;				// bin in BDT score
 	bool Overlay_all = false;			// overlay LLP MC, QCD MC, LLP skim
-	bool Matching_efficiency = true;	// LLP - jet matching efficiency
-	bool perJet = true;
+	bool Matching_efficiency = false;	// LLP - jet matching efficiency
+	bool perJet = false;
 
 	// ----- Jet kinematics in control and signal regions -----//
 
@@ -236,22 +237,34 @@ void MiniTuplePlotter_CR_SR(){
 		cout<<" ---------- Background Study 1: Tagging rates by jet eta ---------- "<<endl;
 		cout<<endl;
 
-		TCut Cut_BDTscore0 	= "bdtscore_LLP125_MS15_perJet > 0"; 
-		TCut Cut_BDTscore 	= "bdtscore_LLP125_MS15_perJet > 0.5"; 
+		TCut Cut_BDTscore0 	= "bdtscore_LLP350_MS80_perJet > 0"; 
+		TCut Cut_BDTscore 	= "bdtscore_LLP350_MS80_perJet > 0.5"; 
 
-		// leading jet, all jet variables
 		class MiniTuplePlotter plotter_BkgEst( filetags_data, path );
-		plotter_BkgEst.SetPlots({P_perJet_Eta, P_perJet_Phi, P_perJet_Pt});
 		plotter_BkgEst.SetTreeName( "PerJet_WPlusJets" );	
-		plotter_BkgEst.SetOutputFileTag("Jet40_CR_SR_v3.7_MC"); 	
 		plotter_BkgEst.SetComparisonCuts({Cut_None, Cut_BDTscore0, Cut_BDTscore});
 		plotter_BkgEst.plot_log_ratio   = true; 
 		plotter_BkgEst.plot_norm 		= false;
-		plotter_BkgEst.SetLegendNames({"Jets from W+Jets events", "with BDT 125 (mS 15) score > 0", "with BDT 125 (mS 15) score > 0.5"});
+		plotter_BkgEst.SetLegendNames({"Jets from W+Jets events", "with BDT 350 (mS 80) score > 0", "with BDT 350 (mS 80) score > 0.5"});
 		plotter_BkgEst.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
 		//plotter_BkgEst.plot_cdf = true;
 		//plotter_BkgEst.plot_reverse_cdf = true;
 		plotter_BkgEst.SetOutputDirectory("BackgroundEstimations");
+		plotter_BkgEst.SetOutputFileTag("Jet40_CR_SR_v3.7_MC"); 	
+		plotter_BkgEst.SetPlots({P_perJet_Pt, P_perJet_Phi, P_perJet_Eta});
+		plotter_BkgEst.Plot("ratio");
+		plotter_BkgEst.ClearFileTrees();
+		plotter_BkgEst.SetOutputFileTag("Jet40_CR_SR_v3.7_MC_variableBins"); 
+		plotter_BkgEst.SetPlots({P_perJet_Pt});
+		plotter_BkgEst.SetVariableBins({0,40,60,80,120,160,300});
+		plotter_BkgEst.Plot("ratio");
+		plotter_BkgEst.ClearFileTrees();
+		plotter_BkgEst.SetPlots({P_perJet_Phi});
+		plotter_BkgEst.SetVariableBins({-3.5,0,3.5});
+		plotter_BkgEst.Plot("ratio");
+		plotter_BkgEst.ClearFileTrees();
+		plotter_BkgEst.SetPlots({P_perJet_Eta});
+		plotter_BkgEst.SetVariableBins({-1.5,-1,-0.5,0,0.5,1,1.5});
 		plotter_BkgEst.Plot("ratio");
 	}
 
@@ -402,39 +415,37 @@ void MiniTuplePlotter_CR_SR(){
 	if (BDT_bins) {
 		// ----- Bin in BDT score ----- //
 
-		// for mH = 125 now, BDT score for 125
+		// for mH = 350 now, BDT score for 350, 80
 
 		cout<<endl;
 		cout<<" ---------- Study 5: Bin in BDT score (MC and data) ---------- "<<endl;
 		cout<<endl;
 
-		class MiniTuplePlotter plotter_allVars_BDTbinsData( filetags_data, path );
-		plotter_allVars_BDTbinsData.SetPlots(analysisVars); 
-		plotter_allVars_BDTbinsData.AddPlot({P_jet0_Pt});
-		plotter_allVars_BDTbinsData.SetTreeName( "WPlusJets" );	
-		plotter_allVars_BDTbinsData.SetOutputFileTag("BDTBins_Jet40_v3.7"); 	
-		plotter_allVars_BDTbinsData.SetComparisonCuts({Cut_BDTscoreNPt99, Cut_BDTscoreNPt98, Cut_BDTscoreNPt95, Cut_BDTscore0, Cut_BDTscorePos}); 
-		plotter_allVars_BDTbinsData.plot_log_ratio    = false; 
-		plotter_allVars_BDTbinsData.SetLegendNames({"Data: BDT score -1 to -0.99", "Data: BDT score -0.99 to -0.98", "Data: BDT score -0.98 to -0.95", "Data: BDT score -0.95 to 0", "Data: BDT score 0 to 1"});
-		plotter_allVars_BDTbinsData.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
-		plotter_allVars_BDTbinsData.SetCuts("jet0_Pt >= 40 && abs(jet0_Eta) <= 1.26");
-		plotter_allVars_BDTbinsData.SetSelectiveCuts("LLPskim", "jet0_NeutralHadEFrac < 0.6");  // BLINDED with track energy fraction (jet0_Track0Pt / jet0_Pt > 0.1) or neutral hadron fraction (jet0_NeutralHadEFrac < 0.6)
-		plotter_allVars_BDTbinsData.SetOutputDirectory("Data_BDTBins");
-		plotter_allVars_BDTbinsData.Plot("ratio");
+		class MiniTuplePlotter plotter_run_BDTbinsData( filetags_data, path );
+		plotter_run_BDTbinsData.SetTreeName( "PerJet_WPlusJets" );	
+		plotter_run_BDTbinsData.SetOutputFileTag("BDTBins_Jet40_v3.7"); 	
+		plotter_run_BDTbinsData.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );			
+		plotter_run_BDTbinsData.SetCuts("perJet_Pt >= 40 && abs(perJet_Eta) <= 1.26 && bdtscore_LLP350_MS80_perJet >= 0.99");
+		plotter_run_BDTbinsData.SetOutputDirectory("BDTBins");
+		plotter_run_BDTbinsData.SetPlots2D({Hist1_Hist2(P_bdtscore_LLP350_MS80_perJet, P_run), Hist1_Hist2(P_bdtscore_LLP350_MS80_perJet, P_eventHT)});
+		plotter_run_BDTbinsData.PlotMany2D();
 
-		class MiniTuplePlotter plotter_allVars_BDTBins( filetags_LLP, path );
-		plotter_allVars_BDTBins.SetPlots(analysisVars); 
-		plotter_allVars_BDTBins.AddPlot({P_jet0_Pt});
-		plotter_allVars_BDTBins.SetTreeName( "NoSel" );	
-		plotter_allVars_BDTBins.SetOutputFileTag("BDTBins_Jet40_v3.7_MC"); 	
-		plotter_allVars_BDTBins.SetComparisonCuts({Cut_BDTscoreN, Cut_BDTscorePt5, Cut_BDTscorePt9, Cut_BDTscorePt95, Cut_BDTscore1}); 
-		plotter_allVars_BDTBins.plot_log_ratio    = false; 
-		plotter_allVars_BDTBins.SetLegendNames({"BDT score -1 to 0", "BDT score 0 to 0.5", "BDT score 0.5 to 0.9", "BDT score 0.9 to 0.95", "BDT score 0.95 to 1"});
-		plotter_allVars_BDTBins.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
-		plotter_allVars_BDTBins.SetCuts("jet0_Pt >= 40 && abs(jet0_Eta) <= 1.26 && jet0_Track0Pt > 4");
-		plotter_allVars_BDTBins.SetSelectiveCuts("LLP_MC", Cut_LLPinHCAL_Jet0);
-		plotter_allVars_BDTBins.SetOutputDirectory("MC_BDTBins");
-		plotter_allVars_BDTBins.Plot("ratio");
+		class MiniTuplePlotter plotter_allVars_BDTbinsData( BDT_files, path ); 
+		plotter_allVars_BDTbinsData.SetPlots(analysisVars_perJet); 
+		plotter_allVars_BDTbinsData.AddPlot({P_perJet_Pt});
+		plotter_allVars_BDTbinsData.AddPlot({P_run});
+		plotter_allVars_BDTbinsData.SetTreeNames( {"PerJet_WPlusJets", "PerJet_LLPmatched", "PerJet_LLPmatched"} );	
+		plotter_allVars_BDTbinsData.SetOutputFileTag("BDTBins_Jet40_v3.7"); 	
+		plotter_allVars_BDTbinsData.SetComparisonCuts({"", Cut_BDTscorePt95, Cut_BDTscorePt99, Cut_BDTscore1}, "LLPskim"); 
+		plotter_allVars_BDTbinsData.plot_log_ratio    = false; 
+		plotter_allVars_BDTbinsData.SetLegendNames({"W+jets: all", "W+jets: BDT score 0.95 - 0.99", "W+jets: BDT score 0.99 to 0.999", "W+jets: BDT score 0.999 to 1", "mH=125, mS=15 (LLP in HCAL, BDT>0.99)", "mH=350, mS=80 (LLP in HCAL, BDT>0.99)"});
+		plotter_allVars_BDTbinsData.colors = { kBlack,  kAzure+7, kGreen+2, kOrange, kMagenta-7, kRed  };
+		plotter_allVars_BDTbinsData.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
+		plotter_allVars_BDTbinsData.SetCuts("perJet_Pt >= 40 && abs(perJet_Eta) <= 1.26");
+		plotter_allVars_BDTbinsData.SetSelectiveCuts("LLP_MC", Cut_matchedLLPinHCAL);
+		plotter_allVars_BDTbinsData.SetSelectiveCuts("LLP_MC", "bdtscore_LLP350_MS80_perJet >= 0.99"); // only look at high scoring BDT jets
+		plotter_allVars_BDTbinsData.SetOutputDirectory("BDTBins");
+		plotter_allVars_BDTbinsData.Plot();
 	}
 
 	if (Overlay_all) {

--- a/MiniTuplePlotter/Gillian/MiniTuplePlotter_CR_SR.C
+++ b/MiniTuplePlotter/Gillian/MiniTuplePlotter_CR_SR.C
@@ -15,21 +15,22 @@ void MiniTuplePlotter_CR_SR(){
 	string path_v3pt4 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.4/minituple_";
 	string path_v3pt5 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.5/minituple_";
 	string path_v3pt6 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.6/minituple_";
-	string path 	  = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_";
+	string path_v3pt7 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_";
+	string path 	  = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_";
 
 	map<string,vector<string>> filetags;
-	filetags["LLP125_mX15"]	= { "v3.7_LLPskim_Run2023Cv4_2024_03_14", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST"};
-	filetags["LLP350_mX80"]	= { "v3.7_LLPskim_Run2023Cv4_2024_03_14", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST"};
-	filetags["LLP125"]		= { "v3.7_LLPskim_Run2023Cv4_2024_03_14", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_03_14_batch2"};
-	filetags["LLP250"]		= { "v3.7_LLPskim_Run2023Cv4_2024_03_14", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_03_14_batch2"};
-	filetags["LLP350"]		= { "v3.7_LLPskim_Run2023Cv4_2024_03_14", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_03_14_batch2"};
+	filetags["LLP125_mX15"]	= { "v3.8_LLPskim_Run2023Cv4_2024_06_03", "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_06_03_TEST"};
+	filetags["LLP350_mX80"]	= { "v3.8_LLPskim_Run2023Cv4_2024_06_03", "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_06_03_TEST"};
+	filetags["LLP125"]		= { "v3.8_LLPskim_Run2023Cv4_2024_06_03", "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_06_03_batch2"};
+	filetags["LLP250"]		= { "v3.8_LLPskim_Run2023Cv4_2024_06_03", "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_06_03_batch2"};
+	filetags["LLP350"]		= { "v3.8_LLPskim_Run2023Cv4_2024_06_03", "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_06_03_batch2"};
 
-	vector<string> filetags_data 		= { "v3.7_LLPskim_Run2023_HADD" };
-	vector<string> filetags_data2 		= { "v3.7_LLPskim_Run2023_HADD", "v3.7_LLPskim_Run2023_HADD" };
-	vector<string> filetags_LLP 		= { "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST" };	
-	vector<string> filetags_all 		= { "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_03_14_batch2", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_03_14_batch2", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_03_14_batch2"};
+	vector<string> filetags_data 		= { "v3.8_LLPskim_Run2023_HADD" };
+	vector<string> filetags_data2 		= { "v3.8_LLPskim_Run2023_HADD", "v3.8_LLPskim_Run2023Cv4_2024_06_03" };
+	vector<string> filetags_LLP 		= { "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_06_03_TEST" };	
+	vector<string> filetags_all 		= { "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_06_03_TEST", "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_06_03_TEST", "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_06_03_batch2", "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_06_03_batch2", "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_06_03_batch2"};
 
-	vector<string> BDT_files 			= {"v3.7_LLPskim_Run2023_HADD", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST"};
+	vector<string> BDT_files 			= {"v3.8_LLPskim_Run2023_HADD", "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_06_03_TEST", "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_06_03_TEST"};
 	vector<string> filetags_all_v3pt0 	= { "v3.0_LLPskim_Run2023Bv1_2023Cv2_2023_11_23", "v2.0_MC_QCD_250k_2023_10_18", "v3.0_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2023_11_23"};
 	vector<string> filetags_QCD 		= { "v2.0_MC_QCD_250k_2023_10_18" };	
 
@@ -114,7 +115,7 @@ void MiniTuplePlotter_CR_SR(){
 		class MiniTuplePlotter plotter_BDTvars( filetags_data2, path );
 		plotter_BDTvars.SetPlots(analysisVars_perJet); 
 		plotter_BDTvars.SetTreeNames( {"PerJet_WPlusJets", "PerJet_NoSel"} );	
-		plotter_BDTvars.SetOutputFileTag("Overlay_BDTinput_perJet_v3.7");
+		plotter_BDTvars.SetOutputFileTag("Overlay_BDTinput_perJet_v3.8");
 		plotter_BDTvars.plot_log_ratio    = false; 
 		plotter_BDTvars.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
 		plotter_BDTvars.SetLegendNames({"LLP skim - W+jets selection", "LLP skim - all"});
@@ -138,7 +139,7 @@ void MiniTuplePlotter_CR_SR(){
 			// class MiniTuplePlotter plotter_BDTvars( filetags[key], path );
 			// plotter_BDTvars.SetPlots(analysisVars); 
 			// plotter_BDTvars.SetTreeNames( {"WPlusJets", "NoSel"} );	
-			// plotter_BDTvars.SetOutputFileTag("Overlay_"+key+"_v3.7");
+			// plotter_BDTvars.SetOutputFileTag("Overlay_"+key+"_v3.8");
 			// plotter_BDTvars.plot_log_ratio    = false; 
 			// //plotter_BDTvars.plot_cdf 		 = true;
 			// //plotter_BDTvars.plot_reverse_cdf  = true;
@@ -156,7 +157,7 @@ void MiniTuplePlotter_CR_SR(){
 			class MiniTuplePlotter plotter_BDTvars_perJet( filetags[key], path );
 			plotter_BDTvars_perJet.SetPlots(analysisVars_perJet); 
 			plotter_BDTvars_perJet.SetTreeNames( {"PerJet_WPlusJets", "PerJet_LLPmatched"} );	
-			plotter_BDTvars_perJet.SetOutputFileTag("Overlay_perJet_"+key+"_v3.7");
+			plotter_BDTvars_perJet.SetOutputFileTag("Overlay_perJet_"+key+"_v3.8");
 			plotter_BDTvars_perJet.plot_log_ratio    = false; 
 			//plotter_BDTvars_perJet.plot_cdf 		 = true;
 			//plotter_BDTvars_perJet.plot_reverse_cdf  = true;
@@ -191,7 +192,7 @@ void MiniTuplePlotter_CR_SR(){
 			class MiniTuplePlotter plotter_track_dR( filetags[key], path );
 			plotter_track_dR.SetPlots({P_perJet_Track0Pt, P_perJet_Track0PtFrac}); 
 			plotter_track_dR.SetTreeNames( {"PerJet_WPlusJets", "PerJet_LLPmatched"} );	
-			plotter_track_dR.SetOutputFileTag("Overlay_perJet_"+key+"_v3.7");
+			plotter_track_dR.SetOutputFileTag("Overlay_perJet_"+key+"_v3.8");
 			plotter_track_dR.plot_log_ratio    = false; 
 			//plotter_track_dR.plot_cdf 		 = true;
 			//plotter_track_dR.plot_reverse_cdf  = true;
@@ -206,7 +207,7 @@ void MiniTuplePlotter_CR_SR(){
 			class MiniTuplePlotter plotter_dR_track( filetags[key], path );
 			plotter_dR_track.SetPlots({P_perJet_Track0dR}); 
 			plotter_dR_track.SetTreeNames( {"PerJet_WPlusJets", "PerJet_LLPmatched"} );	
-			plotter_dR_track.SetOutputFileTag("Overlay_perJet_"+key+"_v3.7");
+			plotter_dR_track.SetOutputFileTag("Overlay_perJet_"+key+"_v3.8");
 			plotter_dR_track.plot_log_ratio    = false; 
 			plotter_dR_track.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
 			plotter_dR_track.SetLegendNames({"LLP skim - track pT < 2", "LLP skim - 2 < track pT < 4", "LLP skim - 4 < track pT < 8", "LLP skim - 8 < track pT", "LLP MC - track pT < 2", "LLP MC - 2 < track pT < 4", "LLP MC - 4 < track pT < 8", "LLP MC - 8 < track pT", });
@@ -220,7 +221,7 @@ void MiniTuplePlotter_CR_SR(){
 			class MiniTuplePlotter plotter_dR_cdf( filetags[key], path );
 			plotter_dR_cdf.SetPlots({P_perJet_Track0dEta, P_perJet_Track0dPhi, P_perJet_Track0dR}); 
 			plotter_dR_cdf.SetTreeNames( {"PerJet_WPlusJets", "PerJet_LLPmatched"} );	
-			plotter_dR_cdf.SetOutputFileTag("Overlay_perJet_"+key+"_v3.7");
+			plotter_dR_cdf.SetOutputFileTag("Overlay_perJet_"+key+"_v3.8");
 			plotter_dR_cdf.plot_log_ratio    = true;
 			plotter_dR_cdf.plot_cdf  = true;
 			plotter_dR_cdf.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
@@ -241,7 +242,7 @@ void MiniTuplePlotter_CR_SR(){
 		class MiniTuplePlotter plotter_BDTvars_perJet( filetags_all, path );
 		plotter_BDTvars_perJet.SetPlots(analysisVars_perJet); 
 		plotter_BDTvars_perJet.SetTreeName( "PerJet_LLPmatched" );	
-		plotter_BDTvars_perJet.SetOutputFileTag("Overlay_perJet_allLLP_v3.7");
+		plotter_BDTvars_perJet.SetOutputFileTag("Overlay_perJet_allLLP_v3.8");
 		plotter_BDTvars_perJet.plot_log_ratio    = false; 
 		//plotter_BDTvars_perJet.plot_cdf 		 = true;
 		//plotter_BDTvars_perJet.plot_reverse_cdf  = true;
@@ -271,11 +272,11 @@ void MiniTuplePlotter_CR_SR(){
 		plotter_BkgEst.SetLegendNames({"Jets from W+Jets events", "with BDT 350 (mS 80) score > 0.5", "with BDT 350 (mS 80) score > 0.9", "with BDT 350 (mS 80) score > 0.99", "with BDT 350 (mS 80) score > 0.999"});
 		plotter_BkgEst.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
 		plotter_BkgEst.SetOutputDirectory("BackgroundEstimations");
-		plotter_BkgEst.SetOutputFileTag("Jet40_CR_SR_v3.7_MC"); 	
+		plotter_BkgEst.SetOutputFileTag("Jet40_CR_SR_v3.8_MC"); 	
 		plotter_BkgEst.SetPlots({P_perJet_Pt, P_perJet_Phi, P_perJet_Eta});
 		plotter_BkgEst.Plot("ratio");
 		plotter_BkgEst.ClearFileTrees();
-		plotter_BkgEst.SetOutputFileTag("Jet40_CR_SR_v3.7_MC_variableBins"); 
+		plotter_BkgEst.SetOutputFileTag("Jet40_CR_SR_v3.8_MC_variableBins"); 
 		plotter_BkgEst.SetPlots({P_perJet_Pt});
 		plotter_BkgEst.SetVariableBins({0,40,60,80,120,160,300});
 		plotter_BkgEst.Plot("ratio");
@@ -298,7 +299,7 @@ void MiniTuplePlotter_CR_SR(){
 		class MiniTuplePlotter plotter_JetVars( filetags_LLP, path );
 		plotter_JetVars.SetPlots(MC_allPlots);
 		plotter_JetVars.SetTreeName( "NoSel" );	
-		plotter_JetVars.SetOutputFileTag("Jet40_CR_SR_v3.7_MC"); 	
+		plotter_JetVars.SetOutputFileTag("Jet40_CR_SR_v3.8_MC"); 	
 		plotter_JetVars.SetComparisonCuts({Cut_LLPinCR_Jet0, Cut_LLPinTrackerNP_Jet0, Cut_LLPinECAL_Jet0, Cut_LLPinHCAL1_Jet0, Cut_LLPinHCAL2_Jet0, Cut_LLPinHCAL34_Jet0});
 		plotter_JetVars.plot_log_ratio    = false; 
 		plotter_JetVars.SetLegendNames({"Tracker: R < 10cm", "Tracker: R > 10cm", "ECAL", "HCAL-D1", "HCAL-D2", "HCAL-D34"});
@@ -313,7 +314,7 @@ void MiniTuplePlotter_CR_SR(){
 		class MiniTuplePlotter plotter_TrackVars( filetags_LLP, path );
 		plotter_TrackVars.SetPlots(trackVars); 
 		plotter_TrackVars.SetTreeName( "NoSel" );	
-		plotter_TrackVars.SetOutputFileTag("Jet40_Track4_CR_SR_v3.7_MC"); 	
+		plotter_TrackVars.SetOutputFileTag("Jet40_Track4_CR_SR_v3.8_MC"); 	
 		plotter_TrackVars.SetComparisonCuts({Cut_LLPinCR_Jet0, Cut_LLPinTrackerNP_Jet0, Cut_LLPinECAL_Jet0, Cut_LLPinHCAL1_Jet0, Cut_LLPinHCAL2_Jet0, Cut_LLPinHCAL34_Jet0});
 		plotter_TrackVars.plot_log_ratio    = false; 
 		plotter_TrackVars.SetLegendNames({"Tracker: R < 10cm", "Tracker: R > 10cm", "ECAL", "HCAL-D1", "HCAL-D2", "HCAL-D34"});
@@ -325,7 +326,7 @@ void MiniTuplePlotter_CR_SR(){
 		// 2D spread of eta - phi, for leading and subleading jet
 		class MiniTuplePlotter plotter_JetVars2D_etaphi( filetags_LLP, path );
 		plotter_JetVars2D_etaphi.SetTreeName( "NoSel" );	
-		plotter_JetVars2D_etaphi.SetOutputFileTag("Jet40_CR_SR_v3.7_MC"); 	
+		plotter_JetVars2D_etaphi.SetOutputFileTag("Jet40_CR_SR_v3.8_MC"); 	
 		plotter_JetVars2D_etaphi.SetComparisonCuts({Cut_LLPinCR_Jet0, Cut_LLPinHCAL_Jet0});
 		plotter_JetVars2D_etaphi.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );			
 		plotter_JetVars2D_etaphi.SetCuts("jet0_Pt >= 40 && abs(jet0_Eta) <= 1.26");
@@ -348,7 +349,7 @@ void MiniTuplePlotter_CR_SR(){
 		class MiniTuplePlotter plotter_Jet0KinematicVars( filetags_LLP, path );
 		plotter_Jet0KinematicVars.SetPlots(jetPlots0); 
 		plotter_Jet0KinematicVars.SetTreeName( "NoSel" );	
-		plotter_Jet0KinematicVars.SetOutputFileTag("CR_SR_v3.7_MC"); 	
+		plotter_Jet0KinematicVars.SetOutputFileTag("CR_SR_v3.8_MC"); 	
 		plotter_Jet0KinematicVars.SetComparisonCuts({Cut_LLPinCR_Jet0, Cut_LLPinHCAL_Jet0});
 		plotter_Jet0KinematicVars.plot_log_ratio    = true;
 		plotter_Jet0KinematicVars.SetLegendNames({"Tracker: R < 10cm", "HCAL-D1234"});
@@ -359,7 +360,7 @@ void MiniTuplePlotter_CR_SR(){
 		class MiniTuplePlotter plotter_Jet1KinematicVars( filetags_LLP, path );
 		plotter_Jet1KinematicVars.SetPlots(jetPlots1); 
 		plotter_Jet1KinematicVars.SetTreeName( "NoSel" );	
-		plotter_Jet1KinematicVars.SetOutputFileTag("CR_SR_v3.7_MC"); 	
+		plotter_Jet1KinematicVars.SetOutputFileTag("CR_SR_v3.8_MC"); 	
 		plotter_Jet1KinematicVars.SetComparisonCuts({Cut_LLPinCR_Jet1, Cut_LLPinHCAL_Jet1});
 		plotter_Jet1KinematicVars.plot_log_ratio    = true;
 		plotter_Jet1KinematicVars.SetLegendNames({"Tracker: R < 10cm", "HCAL-D1234"});
@@ -378,7 +379,7 @@ void MiniTuplePlotter_CR_SR(){
 		class MiniTuplePlotter plotter_RechitVars_NHBinsData( filetags_data, path );
 		plotter_RechitVars_NHBinsData.SetPlots(allPlots);
 		plotter_RechitVars_NHBinsData.SetTreeName( "NoSel" );	
-		plotter_RechitVars_NHBinsData.SetOutputFileTag("NeutralHadBins_Jet40_v3.7"); 	
+		plotter_RechitVars_NHBinsData.SetOutputFileTag("NeutralHadBins_Jet40_v3.8"); 	
 		plotter_RechitVars_NHBinsData.SetComparisonCuts({Cut_NHadpt1, Cut_NHadpt2, Cut_NHadpt3, Cut_NHadpt4, Cut_NHadpt6, Cut_NHad1}); 
 		plotter_RechitVars_NHBinsData.plot_log_ratio    = false; 
 		plotter_RechitVars_NHBinsData.SetLegendNames({"Data: Neutral Hadron 0-0.1", "Data: Neutral Hadron 0.1-0.2", "Data: Neutral Hadron 0.2-0.3", "Data: Neutral Hadron 0.3-0.4", "Data: Neutral Hadron 0.4-0.6", "Data: Neutral Hadron 0.6-1"});
@@ -391,7 +392,7 @@ void MiniTuplePlotter_CR_SR(){
 		class MiniTuplePlotter plotter_RechitVars_NHBins( filetags_LLP, path );
 		plotter_RechitVars_NHBins.SetPlots(MC_allPlots);
 		plotter_RechitVars_NHBins.SetTreeName( "NoSel" );	
-		plotter_RechitVars_NHBins.SetOutputFileTag("NeutralHadBins_Jet40_v3.7_MC"); 	
+		plotter_RechitVars_NHBins.SetOutputFileTag("NeutralHadBins_Jet40_v3.8_MC"); 	
 		plotter_RechitVars_NHBins.SetComparisonCuts({Cut_NHadpt1, Cut_NHadpt2, Cut_NHadpt3, Cut_NHadpt4, Cut_NHadpt6, Cut_NHad1}); 
 		plotter_RechitVars_NHBins.plot_log_ratio    = false; 
 		plotter_RechitVars_NHBins.SetLegendNames({"Neutral Hadron 0-0.1", "Neutral Hadron 0.1-0.2", "Neutral Hadron 0.2-0.3", "Neutral Hadron 0.3-0.4", "Neutral Hadron 0.4-0.6", "Neutral Hadron 0.6-1"});
@@ -411,7 +412,7 @@ void MiniTuplePlotter_CR_SR(){
 		class MiniTuplePlotter plotter_allVars_JetBinsData( filetags_data, path );
 		plotter_allVars_JetBinsData.SetPlots(analysisVars); 
 		plotter_allVars_JetBinsData.SetTreeName( "WPlusJets" );	
-		plotter_allVars_JetBinsData.SetOutputFileTag("JetpTBins_Jet40_v3.7"); 	
+		plotter_allVars_JetBinsData.SetOutputFileTag("JetpTBins_Jet40_v3.8"); 	
 		plotter_allVars_JetBinsData.SetComparisonCuts({Cut_JetPt40, Cut_JetPt80, Cut_JetPt120, Cut_JetPt160, Cut_JetPt200}); 
 		plotter_allVars_JetBinsData.plot_log_ratio    = false; 
 		plotter_allVars_JetBinsData.SetLegendNames({"Data: Jet p_{T} 40-80 GeV", "Data: Jet p_{T} 80-120 GeV", "Data: Jet p_{T} 120-160 GeV", "Data: Jet p_{T} 160-200 GeV", "Data: Jet p_{T} 200+ GeV"});
@@ -424,7 +425,7 @@ void MiniTuplePlotter_CR_SR(){
 		class MiniTuplePlotter plotter_allVars_JetBins( filetags_LLP, path );
 		plotter_allVars_JetBins.SetPlots(analysisVars); 
 		plotter_allVars_JetBins.SetTreeName( "NoSel" );	
-		plotter_allVars_JetBins.SetOutputFileTag("JetpTBins_Jet40_v3.7_MC"); 	
+		plotter_allVars_JetBins.SetOutputFileTag("JetpTBins_Jet40_v3.8_MC"); 	
 		plotter_allVars_JetBins.SetComparisonCuts({Cut_JetPt40, Cut_JetPt80, Cut_JetPt120, Cut_JetPt160, Cut_JetPt200}); 
 		plotter_allVars_JetBins.plot_log_ratio    = false; 
 		plotter_allVars_JetBins.SetLegendNames({"Jet p_{T} 40-80 GeV", "Jet p_{T} 80-120 GeV", "Jet p_{T} 120-160 GeV", "Jet p_{T} 160-200 GeV", "Jet p_{T} 200+ GeV"});
@@ -445,7 +446,7 @@ void MiniTuplePlotter_CR_SR(){
 
 		class MiniTuplePlotter plotter_run_BDTbinsData( filetags_data, path );
 		plotter_run_BDTbinsData.SetTreeName( "PerJet_WPlusJets" );	
-		plotter_run_BDTbinsData.SetOutputFileTag("BDTBins_Jet40_v3.7"); 	
+		plotter_run_BDTbinsData.SetOutputFileTag("BDTBins_Jet40_v3.8"); 	
 		plotter_run_BDTbinsData.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );			
 		plotter_run_BDTbinsData.SetCuts("perJet_Pt >= 40 && abs(perJet_Eta) <= 1.26 && bdtscore_LLP350_MS80_perJet >= 0.99");
 		plotter_run_BDTbinsData.SetOutputDirectory("BDTBins");
@@ -457,7 +458,7 @@ void MiniTuplePlotter_CR_SR(){
 		plotter_allVars_BDTbinsData.AddPlot({P_perJet_Pt});
 		plotter_allVars_BDTbinsData.AddPlot({P_run});
 		plotter_allVars_BDTbinsData.SetTreeNames( {"PerJet_WPlusJets", "PerJet_LLPmatched", "PerJet_LLPmatched"} );	
-		plotter_allVars_BDTbinsData.SetOutputFileTag("BDTBins_Jet40_v3.7"); 	
+		plotter_allVars_BDTbinsData.SetOutputFileTag("BDTBins_Jet40_v3.8"); 	
 		plotter_allVars_BDTbinsData.SetComparisonCuts({"", Cut_BDTscorePt95, Cut_BDTscorePt99, Cut_BDTscore1}, "LLPskim"); 
 		plotter_allVars_BDTbinsData.plot_log_ratio    = false; 
 		plotter_allVars_BDTbinsData.SetLegendNames({"W+jets: all", "W+jets: BDT score 0.95 - 0.99", "W+jets: BDT score 0.99 to 0.999", "W+jets: BDT score 0.999 to 1", "mH=125, mS=15 (LLP in HCAL, BDT>0.99)", "mH=350, mS=80 (LLP in HCAL, BDT>0.99)"});
@@ -514,7 +515,7 @@ void MiniTuplePlotter_CR_SR(){
 			class MiniTuplePlotter plotter_LLP_Jet_Match( filetags_LLP, path );
 			plotter_LLP_Jet_Match.SetPlots({P_perJet_MatchedLLP_DecayR, P_perJet_MatchedLLP_Eta});
 			plotter_LLP_Jet_Match.SetTreeName( "PerJet_LLPmatched" );	
-			plotter_LLP_Jet_Match.SetOutputFileTag("Jet40_v3.7_MC"); 	
+			plotter_LLP_Jet_Match.SetOutputFileTag("Jet40_v3.8_MC"); 	
 			plotter_LLP_Jet_Match.SetComparisonCuts({"abs(perJet_Eta) <= 1.26", "abs(perJet_Eta) <= 1.26 && perJet_MatchedLLP_DecayR > 0", "abs(perJet_Eta) <= 1.26 && perJet_Pt >= 40", "abs(perJet_Eta) <= 1.26 && perJet_Pt >= 60", "abs(perJet_Eta) <= 1.26 && perJet_Pt >= 80", "abs(perJet_Eta) <= 1.26 && perJet_Pt >= 100"}); 
 			plotter_LLP_Jet_Match.plot_log_ratio    = false; 
 			plotter_LLP_Jet_Match.plot_norm 		= false;
@@ -529,7 +530,7 @@ void MiniTuplePlotter_CR_SR(){
 			class MiniTuplePlotter plotter_LLP_Jet_PtDiff( filetags_LLP, path );
 			plotter_LLP_Jet_PtDiff.SetPlots({P_jet0_llp0_ptDiff, P_jet0_llp1_ptDiff});
 			plotter_LLP_Jet_PtDiff.SetTreeName( "NoSel" );	
-			plotter_LLP_Jet_PtDiff.SetOutputFileTag("Jet40_v3.7_MC"); 	
+			plotter_LLP_Jet_PtDiff.SetOutputFileTag("Jet40_v3.8_MC"); 	
 			plotter_LLP_Jet_PtDiff.SetComparisonCuts({Cut_LLP0inCR, Cut_LLP0inTrackerNP, Cut_LLP0inECAL, Cut_LLPinHCAL_d1, Cut_LLP0inHCAL_d2, Cut_LLP0inHCAL_d34}); 
 			plotter_LLP_Jet_PtDiff.plot_log_ratio    = false; 
 			plotter_LLP_Jet_PtDiff.SetLegendNames({"LLP0: Tracker: R < 10cm", "LLP0: Tracker: R > 10cm", "LLP0: ECAL", "LLP0: HCAL-D1", "LLP0: HCAL-D2", "LLP0: HCAL-D34"});
@@ -541,7 +542,7 @@ void MiniTuplePlotter_CR_SR(){
 			class MiniTuplePlotter plotter_LLP_Jet_Match( filetags_LLP, path );
 			plotter_LLP_Jet_Match.SetPlots({P_LLP0_DecayR, P_LLP0_isTruthMatched_Eta});
 			plotter_LLP_Jet_Match.SetTreeName( "NoSel" );	
-			plotter_LLP_Jet_Match.SetOutputFileTag("Jet40_v3.7_MC"); 	
+			plotter_LLP_Jet_Match.SetOutputFileTag("Jet40_v3.8_MC"); 	
 			plotter_LLP_Jet_Match.SetComparisonCuts({"abs(jet0_Eta) <= 1.26 || abs(jet1_Eta) <= 1.26 || abs(jet2_Eta) <= 1.26 || abs(jet3_Eta) <= 1.26 || abs(jet4_Eta) <= 1.26 || abs(jet5_Eta) <= 1.26", "LLP0_isTruthMatched == 1", "LLP0_isTruthMatched_Jet40 == 1", "LLP0_isTruthMatched_Jet60 == 1", "LLP0_isTruthMatched_Jet80 == 1", "LLP0_isTruthMatched_Jet100 == 1"}); 
 			plotter_LLP_Jet_Match.plot_log_ratio    = false; 
 			plotter_LLP_Jet_Match.plot_norm 		= false;
@@ -555,7 +556,7 @@ void MiniTuplePlotter_CR_SR(){
 			class MiniTuplePlotter plotter_LLP_Jet_Match_tight( filetags_LLP, path );
 			plotter_LLP_Jet_Match_tight.SetPlots({P_LLP0_DecayR});
 			plotter_LLP_Jet_Match_tight.SetTreeName( "NoSel" );	
-			plotter_LLP_Jet_Match_tight.SetOutputFileTag("Jet40_v3.7_MC"); 	
+			plotter_LLP_Jet_Match_tight.SetOutputFileTag("Jet40_v3.8_MC"); 	
 			plotter_LLP_Jet_Match_tight.SetComparisonCuts({"abs(jet0_Eta) <= 1.26 || abs(jet1_Eta) <= 1.26 || abs(jet2_Eta) <= 1.26", "LLP0_isTruthMatched == 1 && abs(LLP0_isTruthMatched_Eta) <= 1.26", "LLP0_isTruthMatched_Jet40 == 1 && abs(LLP0_isTruthMatched_Jet40Eta) <= 1.26", "LLP0_isTruthMatched_Jet60 == 1 && abs(LLP0_isTruthMatched_Jet60Eta) <= 1.26", "LLP0_isTruthMatched_Jet80 == 1 && abs(LLP0_isTruthMatched_Jet80Eta) <= 1.26", "LLP0_isTruthMatched_Jet100 == 1 && abs(LLP0_isTruthMatched_Jet100Eta) <= 1.26"}); 
 			plotter_LLP_Jet_Match_tight.plot_log_ratio    = false; 
 			plotter_LLP_Jet_Match_tight.plot_norm 		= false;

--- a/MiniTuplePlotter/Gillian/MiniTuplePlotter_CR_SR.C
+++ b/MiniTuplePlotter/Gillian/MiniTuplePlotter_CR_SR.C
@@ -25,6 +25,7 @@ void MiniTuplePlotter_CR_SR(){
 	filetags["LLP350"]		= { "v3.7_LLPskim_Run2023Cv4_2024_03_14", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_03_14_batch2"};
 
 	vector<string> filetags_data 		= { "v3.7_LLPskim_Run2023_HADD" };
+	vector<string> filetags_data2 		= { "v3.7_LLPskim_Run2023_HADD", "v3.7_LLPskim_Run2023_HADD" };
 	vector<string> filetags_LLP 		= { "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST" };	
 	vector<string> filetags_all 		= { "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_03_14_batch2", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_03_14_batch2", "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_03_14_batch2"};
 
@@ -70,15 +71,16 @@ void MiniTuplePlotter_CR_SR(){
 										P_jet0_LeadingRechitE, P_jet0_LeadingRechitEFracJet, P_jet0_Sphiphi};
 	vector<PlotParams> analysisVars_perJet	= { P_perJet_NeutralHadEFrac, P_perJet_ChargedHadEFrac, P_perJet_MuonEFrac, P_perJet_PhoEFrac, P_perJet_EleEFrac,
 										// P_perJet_NeutralHadEFrac_zero, P_perJet_ChargedHadEFrac_zero, P_perJet_MuonEFrac_zero, P_perJet_PhoEFrac_zero, P_perJet_EleEFrac_zero,
-										P_perJet_Track0Pt, P_perJet_Track0PtFrac, P_perJet_Track1Pt, P_perJet_Track1PtFrac,
+										// P_perJet_Track0Pt, P_perJet_Track1Pt, 
+										P_perJet_Track0PtFrac, P_perJet_Track1PtFrac,
 										P_perJet_Track0dEta, P_perJet_Track0dPhi, P_perJet_Track0dR, P_perJet_Track1dEta, P_perJet_Track1dPhi, P_perJet_Track1dR, 
 										P_perJet_EnergyFrac_Depth1, P_perJet_EnergyFrac_Depth2, P_perJet_EnergyFrac_Depth3, P_perJet_EnergyFrac_Depth4,
-										P_perJet_Eta, P_perJet_Phi, P_perJet_Mass,
-										P_perJet_LeadingRechitE, P_perJet_AllRechitE, P_perJet_LeadingRechitEFracJet, P_perJet_AllRechitEFracJet,
-										P_perJet_Sphiphi, P_perJet_Setaeta, P_perJet_Setaphi,
-										P_perJet_Track0dzOverErr, P_perJet_Track1dzOverErr, P_perJet_Track0dxyOverErr, P_perJet_Track1dxyOverErr,
-										P_perJet_Track0dzToPV, P_perJet_Track1dzToPV, P_perJet_Track0dxyToBS, P_perJet_Track1dxyToBS,
-										P_perJet_OtherLLP_DecayR};	
+										P_perJet_Eta, // P_perJet_Phi, P_perJet_Mass, P_perJet_LeadingRechitE, P_perJet_AllRechitE, P_perJet_AllRechitEFracJet,
+										P_perJet_LeadingRechitEFracJet, 
+										P_perJet_Sphiphi}; // P_perJet_Setaeta, P_perJet_Setaphi,
+										// P_perJet_Track0dzOverErr, P_perJet_Track1dzOverErr, P_perJet_Track0dxyOverErr, P_perJet_Track1dxyOverErr,
+										// P_perJet_Track0dzToPV, P_perJet_Track1dzToPV, P_perJet_Track0dxyToBS, P_perJet_Track1dxyToBS,
+										// P_perJet_OtherLLP_DecayR};	
 										// P_jet0_Track0nMissingInnerHits, P_jet0_Track0nMissingOuterHits, P_jet0_Track0nPixelHits, P_jet0_Track0nHits,			// only in v3.2 or newer
 										// P_jet0_EtaSpread, P_jet0_PhiSpread, P_jet0_EtaSpread_energy, P_jet0_PhiSpread_energy,
 										// P_jet0_TDCaverage, P_jet0_TDCaverage_Eweight, P_jet0_TDCnDelayed, 
@@ -87,10 +89,11 @@ void MiniTuplePlotter_CR_SR(){
 
 	#include "../RegionCuts.h"
 
+	bool Skim_WJets = true;				// BDT input variables, plot LLP skim vs W+Jets selection
 	bool LLP_WJets = false;				// analysis variables for LLP and W+Jets overlayed
 	bool track_dR_study = false;		// track vars with diff dR cuts, dR with diff track cuts
 	bool overlay_LLP = false;			// overlay analysis variables for each LLP mass point
-	bool Bkg_est = true;				// look at jet tagging vars by jet eta for probability estimations
+	bool Bkg_est = false;				// look at jet tagging vars by jet eta for probability estimations
 
 	bool LLP_all = false;				// all variables, track vars with leading track < 4 study, eta-phi spread
 	bool Jet_vars = false; 				// jet kinematics without a pT cut
@@ -102,6 +105,24 @@ void MiniTuplePlotter_CR_SR(){
 	bool perJet = false;
 
 	// ----- Jet kinematics in control and signal regions -----//
+
+	if (Skim_WJets) {
+		cout<<endl;
+		cout<<" ---------- CR / SR Study: All BDT input variables for LLP skim and W+jets (background) ---------- "<<endl;
+		cout<<endl;
+
+		class MiniTuplePlotter plotter_BDTvars( filetags_data2, path );
+		plotter_BDTvars.SetPlots(analysisVars_perJet); 
+		plotter_BDTvars.SetTreeNames( {"PerJet_WPlusJets", "PerJet_NoSel"} );	
+		plotter_BDTvars.SetOutputFileTag("Overlay_BDTinput_perJet_v3.7");
+		plotter_BDTvars.plot_log_ratio    = false; 
+		plotter_BDTvars.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
+		plotter_BDTvars.SetLegendNames({"LLP skim - W+jets selection", "LLP skim - all"});
+		plotter_BDTvars.SetCuts("perJet_Pt >= 40 && abs(perJet_Eta) <= 1.26");
+		plotter_BDTvars.colors = { kGray, kViolet+4 };
+		plotter_BDTvars.SetOutputDirectory("Overlay_BDTinput_perJet");
+		plotter_BDTvars.Plot();
+	}
 
 	if (LLP_WJets) {
 		cout<<endl;
@@ -237,18 +258,18 @@ void MiniTuplePlotter_CR_SR(){
 		cout<<" ---------- Background Study 1: Tagging rates by jet eta ---------- "<<endl;
 		cout<<endl;
 
-		TCut Cut_BDTscore0 	= "bdtscore_LLP350_MS80_perJet > 0"; 
-		TCut Cut_BDTscore 	= "bdtscore_LLP350_MS80_perJet > 0.5"; 
+		TCut Cut_BDTscore5 	= "bdtscore_LLP350_MS80_perJet > 0.5"; 
+		TCut Cut_BDTscore9 	= "bdtscore_LLP350_MS80_perJet > 0.9"; 
+		TCut Cut_BDTscore99 = "bdtscore_LLP350_MS80_perJet > 0.99"; 
+		TCut Cut_BDTscore999= "bdtscore_LLP350_MS80_perJet > 0.999"; 
 
 		class MiniTuplePlotter plotter_BkgEst( filetags_data, path );
 		plotter_BkgEst.SetTreeName( "PerJet_WPlusJets" );	
-		plotter_BkgEst.SetComparisonCuts({Cut_None, Cut_BDTscore0, Cut_BDTscore});
+		plotter_BkgEst.SetComparisonCuts({Cut_None, Cut_BDTscore5, Cut_BDTscore9, Cut_BDTscore99, Cut_BDTscore999});
 		plotter_BkgEst.plot_log_ratio   = true; 
 		plotter_BkgEst.plot_norm 		= false;
-		plotter_BkgEst.SetLegendNames({"Jets from W+Jets events", "with BDT 350 (mS 80) score > 0", "with BDT 350 (mS 80) score > 0.5"});
+		plotter_BkgEst.SetLegendNames({"Jets from W+Jets events", "with BDT 350 (mS 80) score > 0.5", "with BDT 350 (mS 80) score > 0.9", "with BDT 350 (mS 80) score > 0.99", "with BDT 350 (mS 80) score > 0.999"});
 		plotter_BkgEst.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
-		//plotter_BkgEst.plot_cdf = true;
-		//plotter_BkgEst.plot_reverse_cdf = true;
 		plotter_BkgEst.SetOutputDirectory("BackgroundEstimations");
 		plotter_BkgEst.SetOutputFileTag("Jet40_CR_SR_v3.7_MC"); 	
 		plotter_BkgEst.SetPlots({P_perJet_Pt, P_perJet_Phi, P_perJet_Eta});
@@ -264,7 +285,7 @@ void MiniTuplePlotter_CR_SR(){
 		plotter_BkgEst.Plot("ratio");
 		plotter_BkgEst.ClearFileTrees();
 		plotter_BkgEst.SetPlots({P_perJet_Eta});
-		plotter_BkgEst.SetVariableBins({-1.5,-1,-0.5,0,0.5,1,1.5});
+		plotter_BkgEst.SetVariableBins({-1.5,-1.26,-1,-0.75,-0.5,-0.25,0,0.25,0.5,0.75,1,1.26,1.5});
 		plotter_BkgEst.Plot("ratio");
 	}
 
@@ -333,6 +354,7 @@ void MiniTuplePlotter_CR_SR(){
 		plotter_Jet0KinematicVars.SetLegendNames({"Tracker: R < 10cm", "HCAL-D1234"});
 		plotter_Jet0KinematicVars.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
 		plotter_Jet0KinematicVars.Plot("ratio");	
+		plotter_Jet0KinematicVars.Plot("efficiency");	
 		
 		class MiniTuplePlotter plotter_Jet1KinematicVars( filetags_LLP, path );
 		plotter_Jet1KinematicVars.SetPlots(jetPlots1); 
@@ -520,11 +542,12 @@ void MiniTuplePlotter_CR_SR(){
 			plotter_LLP_Jet_Match.SetPlots({P_LLP0_DecayR, P_LLP0_isTruthMatched_Eta});
 			plotter_LLP_Jet_Match.SetTreeName( "NoSel" );	
 			plotter_LLP_Jet_Match.SetOutputFileTag("Jet40_v3.7_MC"); 	
-			plotter_LLP_Jet_Match.SetComparisonCuts({"abs(jet0_Eta) <= 1.26 || abs(jet1_Eta) <= 1.26 || abs(jet2_Eta) <= 1.26", "LLP0_isTruthMatched == 1", "LLP0_isTruthMatched_Jet40 == 1", "LLP0_isTruthMatched_Jet60 == 1", "LLP0_isTruthMatched_Jet80 == 1", "LLP0_isTruthMatched_Jet100 == 1"}); 
+			plotter_LLP_Jet_Match.SetComparisonCuts({"abs(jet0_Eta) <= 1.26 || abs(jet1_Eta) <= 1.26 || abs(jet2_Eta) <= 1.26 || abs(jet3_Eta) <= 1.26 || abs(jet4_Eta) <= 1.26 || abs(jet5_Eta) <= 1.26", "LLP0_isTruthMatched == 1", "LLP0_isTruthMatched_Jet40 == 1", "LLP0_isTruthMatched_Jet60 == 1", "LLP0_isTruthMatched_Jet80 == 1", "LLP0_isTruthMatched_Jet100 == 1"}); 
 			plotter_LLP_Jet_Match.plot_log_ratio    = false; 
 			plotter_LLP_Jet_Match.plot_norm 		= false;
 			plotter_LLP_Jet_Match.SetLegendNames({"LLP0 Decay Position", "LLP0 Matched, Jet p_{T} > 0", "LLP0 Matched, Jet p_{T} > 40", "LLP0 Matched, Jet p_{T} > 60", "LLP0 Matched, Jet p_{T} > 80", "LLP0 Matched, Jet p_{T} > 100"});
 			plotter_LLP_Jet_Match.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
+			// plotter_LLP_Jet_Match.SetCuts("LLP0_Pt > 40 && abs(LLP0_Eta) <= 1.26 && (abs(jet0_Eta) <= 1.26 || abs(jet1_Eta) <= 1.26 || abs(jet2_Eta) <= 1.26 || abs(jet3_Eta) <= 1.26 || abs(jet4_Eta) <= 1.26 || abs(jet5_Eta) <= 1.26)"); 
 			plotter_LLP_Jet_Match.SetCuts("LLP0_Pt > 40 && abs(LLP0_Eta) <= 1.26"); 
 			plotter_LLP_Jet_Match.SetOutputDirectory("MC_LLP_Jet_Match");
 			plotter_LLP_Jet_Match.Plot("ratio");

--- a/MiniTuplePlotter/Gillian/MiniTuplePlotter_HLT_Effs.C
+++ b/MiniTuplePlotter/Gillian/MiniTuplePlotter_HLT_Effs.C
@@ -51,11 +51,17 @@ void MiniTuplePlotter_HLT_Effs(){
 
 	// to do -- make a new version that is jet based!
 
-	// vector<string> filetag_keys_to_loop = {"LLP125", "LLP250", "LLP350", "LLP125_mX15", "LLP350_mX80"};
 	vector<string> filetag_keys_to_loop = {"LLP350_80_ctau500mm", "LLP125_50_ctau10m", "LLP125_15_ctau10m", "LLP125_15_ctau1m", "LLP125_15_ctau3m", "LLP125_50_ctau3m", "LLP250_120_ctau10m", "LLP350_160_ctau10m"};
 
 	vector<string> jet_E = {"100"}; //{"60", "100"};
 	vector<string> event_HT = {"250"}; // {"200", "170"};
+
+	vector<vector<double>> variable_bins = {{0, 20, 40, 60, 80, 100, 120, 140, 160, 180, 200, 220, 240, 260, 285, 310, 340, 370, 400, 430, 460, 495, 530, 570, 620, 680, 740, 800, 920, 1200},
+											{40, 43, 46, 49, 52, 55, 58, 61, 64, 67, 70, 73, 76, 79, 82, 86, 90, 95, 100, 105, 110, 115, 120, 127, 134, 141, 148, 156, 164, 172, 180, 190, 200, 210, 225, 250},
+											{40, 43, 46, 49, 52, 55, 58, 61, 64, 67, 70, 73, 76, 79, 82, 86, 90, 95, 100, 105, 110, 115, 120, 127, 134, 141, 148, 156, 164, 172, 180, 190, 200, 210, 225, 250},
+											{-1.26, -1.16, -1.06, -0.96, -0.86, -0.76, -0.66, -0.56, -0.46, -0.36, -0.26, -0.16, -0.06, 0.06, 0.16, 0.26, 0.36, 0.46, 0.56, 0.66, 0.76, 0.86, 0.96, 1.06, 1.16, 1.26},
+											{-3.15, -3, -2.85, -2.7, -2.55, -2.4, -2.25, -2.1, -1.95, -1.8, -1.65, -1.5, -1.35, -1.2, -1.05, -0.9, -0.75, -0.6, -0.45, -0.3, -0.15, 0, 0.15, 0.3, 0.45, 0.6, 0.75, 0.9, 1.05, 1.2, 1.35, 1.5, 1.65, 1.8, 1.95, 2.1, 2.25, 2.4, 2.55, 2.7, 2.85, 3.0, 3.15} };
+	vector<vector<PlotParams>> plot_type = { {P_eventHT}, {P_perJet_Pt}, {P_perJet_E}, {P_perJet_Eta}, {P_perJet_Phi} };
 
 	for( auto key: filetag_keys_to_loop){
 
@@ -77,7 +83,7 @@ void MiniTuplePlotter_HLT_Effs(){
 			eff_LLPdisplacement.SetComparisonCuts({Cut_None, Cut_HLTpassed1, Cut_AnyLLP_HLT}); 
 			// eff_LLPdisplacement.colors = { kWhite, kOrange, kGreen+2 }; // to just see trigger efficiency 
 			eff_LLPdisplacement.colors = { kBlack, kAzure+7, kViolet+4 };
-			eff_LLPdisplacement.SetLegendNames({"No cuts", "Monitoring HLT passed", "LLP HLT passed"});
+			eff_LLPdisplacement.SetLegendNames({"No cuts", "LLP L1 passed", "LLP HLT passed"});
 			// eff_LLPdisplacement.Plot("ratio");
 			eff_LLPdisplacement.Plot("efficiency");
 			eff_LLPdisplacement.ClearFileTrees(); 														// reset, and cut on each HLT group
@@ -88,31 +94,34 @@ void MiniTuplePlotter_HLT_Effs(){
 			eff_LLPdisplacement.Plot("ratio");
 		}
 
-		// cut on LLP displacement, plot efficiency vs jet pT, E, eta, phi, event HTT
-		class MiniTuplePlotter plotter_HLTeffMC( filetags[key], path );
-//		plotter_HLTeffMC.SetPlots({P_jet0_E, P_jet0_Pt, P_jet0_Eta, P_jet0_Phi, P_eventHT});
-		plotter_HLTeffMC.SetPlots({P_perJet_E, P_perJet_Pt, P_perJet_Eta, P_perJet_Phi, P_eventHT});
-//		plotter_HLTeffMC.SetTreeName( "NoSel" ); 
-		plotter_HLTeffMC.SetTreeName( "PerJet_LLPmatched" );
-		plotter_HLTeffMC.SetOutputFileTag("HLT_v3_MC_"+key);
-		plotter_HLTeffMC.SetOutputDirectory("HLT_Efficiencies");
-		plotter_HLTeffMC.plot_norm 			= false;
-		plotter_HLTeffMC.plot_log_ratio   	= true;
-		plotter_HLTeffMC.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
-//		plotter_HLTeffMC.SetSelectiveCuts("MC", Cut_LLPinHCAL123_Jet0);
-		plotter_HLTeffMC.SetSelectiveCuts("MC", Cut_matchedLLPinHCAL34);		// region for LLP decay, and require LLP is matched to jet 0
-		plotter_HLTeffMC.SetComparisonCuts({Cut_None, Cut_HLTpassed1, Cut_AnyLLP_HLT}); 
-		plotter_HLTeffMC.colors = { kBlack, kAzure+7, kViolet+4 };
-		plotter_HLTeffMC.SetLegendNames({"No cuts", "Monitoring HLT passed", "LLP HLT passed"});
-		// plotter_HLTeffMC.Plot("ratio");
-		plotter_HLTeffMC.Plot("efficiency");
-		plotter_HLTeffMC.ClearFileTrees(); 																// reset, and cut on each HLT group.
-		plotter_HLTeffMC.SetOutputFileTag("HLT_v3_MC_"+key+"_HLTsplit");
-		plotter_HLTeffMC.colors = { kBlack, kOrange, kGreen+2, kAzure+7, kBlue-4, kViolet+4, kMagenta-7, kRed  };
-		plotter_HLTeffMC.SetComparisonCuts({Cut_HLTpassed1, Cut_AnyLLP_HLT, Cut_HLTpassed2, Cut_HLTpassed9, Cut_HLTpassed5, Cut_HLTpassed11}); 
-		plotter_HLTeffMC.SetLegendNames({"Monitoring HLT passed", "LLP HLT passed", "Displaced dijet, <=1 prompt track", "Displaced dijet, <=2 prompt tracks", "Displaced dijet, 1 displaced track", "Delayed jet, ECAL jet timing"});
-		plotter_HLTeffMC.Plot("ratio");
-
+		for( int i = 0; i < variable_bins.size(); i++ ) {
+			// cut on LLP displacement, plot efficiency vs jet pT, E, eta, phi, event HTT
+			class MiniTuplePlotter plotter_HLTeffMC( filetags[key], path );
+	//		plotter_HLTeffMC.SetPlots({P_jet0_E, P_jet0_Pt, P_jet0_Eta, P_jet0_Phi, P_eventHT});
+	//		plotter_HLTeffMC.SetPlots({P_perJet_E, P_perJet_Pt, P_perJet_Eta, P_perJet_Phi, P_eventHT});
+			plotter_HLTeffMC.SetPlots(plot_type[i]);
+	//		plotter_HLTeffMC.SetTreeName( "NoSel" ); 
+			plotter_HLTeffMC.SetTreeName( "PerJet_LLPmatched" );
+			plotter_HLTeffMC.SetOutputFileTag("HLT_v3_MC_"+key);
+			plotter_HLTeffMC.SetOutputDirectory("HLT_Efficiencies");
+			plotter_HLTeffMC.plot_norm 			= false;
+			plotter_HLTeffMC.plot_log_ratio   	= true;
+			plotter_HLTeffMC.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 ); // works when efficiency legend uses -0.45 for x (upper left) or -0.3 for y (middle right)
+			plotter_HLTeffMC.SetVariableBins( variable_bins[i] );
+	//		plotter_HLTeffMC.SetSelectiveCuts("MC", Cut_LLPinHCAL123_Jet0);
+			plotter_HLTeffMC.SetSelectiveCuts("MC", Cut_matchedLLPinHCAL34);		// region for LLP decay, and require LLP is matched to jet 0
+			plotter_HLTeffMC.SetComparisonCuts({Cut_None, Cut_HLTpassed1, Cut_AnyLLP_HLT}); 
+			plotter_HLTeffMC.colors = { kBlack, kAzure+7, kViolet+4 };
+			plotter_HLTeffMC.SetLegendNames({"No cuts", "LLP L1 passed", "LLP HLT passed"});
+			// plotter_HLTeffMC.Plot("ratio");
+			plotter_HLTeffMC.Plot("efficiency");
+			plotter_HLTeffMC.ClearFileTrees(); 																// reset, and cut on each HLT group.
+			plotter_HLTeffMC.SetOutputFileTag("HLT_v3_MC_"+key+"_HLTsplit");
+			plotter_HLTeffMC.colors = { kBlack, kOrange, kGreen+2, kAzure+7, kBlue-4, kViolet+4, kMagenta-7, kRed  };
+			plotter_HLTeffMC.SetComparisonCuts({Cut_HLTpassed1, Cut_AnyLLP_HLT, Cut_HLTpassed2, Cut_HLTpassed9, Cut_HLTpassed5, Cut_HLTpassed11}); 
+			plotter_HLTeffMC.SetLegendNames({"Monitoring HLT passed", "LLP HLT passed", "Displaced dijet, <=1 prompt track", "Displaced dijet, <=2 prompt tracks", "Displaced dijet, 1 displaced track", "Delayed jet, ECAL jet timing"});
+			plotter_HLTeffMC.Plot("ratio");
+		}
 	}
 
 	if (September) {

--- a/MiniTuplePlotter/Gillian/MiniTuplePlotter_HLT_Effs.C
+++ b/MiniTuplePlotter/Gillian/MiniTuplePlotter_HLT_Effs.C
@@ -14,14 +14,21 @@ void MiniTuplePlotter_HLT_Effs(){
 	// vector<string> filetags_MC = 	{ "v1.2_MCsignal_500k_2023_08_31" };
 
 	string path_v3 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.0/minituple_";
-	string path = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_";
+	string path = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_";
 
 	map<string,vector<string>> filetags;
 	filetags["LLP125"]	= { "v3.0_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2023_11_23"};
 	// filetags["LLP350"]	= { "v3.0_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2023_11_29"};
 
-	filetags["LLP350"]	= { "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST"};
-	filetags["LLP125_50"]	= { "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau10000_13p6TeV_2024_05_09"};
+	filetags["LLP350_80_ctau500mm"]	= { "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_06_03_TEST"};
+	filetags["LLP125_50_ctau10m"]	= { "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau10000_13p6TeV_2024_06_03"};
+
+	filetags["LLP125_15_ctau10m"]	= { "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau10000_13p6TeV_2024_06_03"};
+	filetags["LLP125_15_ctau1m"]	= { "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_06_03_TEST"};
+	filetags["LLP125_15_ctau3m"]	= { "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau3000_13p6TeV_2024_06_03"};
+	filetags["LLP125_50_ctau3m"]	= { "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_06_03_batch1"};
+	filetags["LLP250_120_ctau10m"]	= { "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_06_03_batch1"};
+	filetags["LLP350_160_ctau10m"]	= { "v3.8_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_06_03_batch1"};
 	
 	// filetags["LLP125_mX15"]	= { "v3.6_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_02_TEST"};
 	// filetags["LLP350_mX80"]	= { "v3.6_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_02_TEST"};
@@ -45,10 +52,10 @@ void MiniTuplePlotter_HLT_Effs(){
 	// to do -- make a new version that is jet based!
 
 	// vector<string> filetag_keys_to_loop = {"LLP125", "LLP250", "LLP350", "LLP125_mX15", "LLP350_mX80"};
-	vector<string> filetag_keys_to_loop = {"LLP350"}; //, "LLP125_50"};
+	vector<string> filetag_keys_to_loop = {"LLP350_80_ctau500mm", "LLP125_50_ctau10m", "LLP125_15_ctau10m", "LLP125_15_ctau1m", "LLP125_15_ctau3m", "LLP125_50_ctau3m", "LLP250_120_ctau10m", "LLP350_160_ctau10m"};
 
-	vector<string> jet_E = {"60"}; //{"60", "100"};
-	vector<string> event_HT = {"200"}; // {"200", "170"};
+	vector<string> jet_E = {"100"}; //{"60", "100"};
+	vector<string> event_HT = {"250"}; // {"200", "170"};
 
 	for( auto key: filetag_keys_to_loop){
 
@@ -66,7 +73,7 @@ void MiniTuplePlotter_HLT_Effs(){
 			eff_LLPdisplacement.plot_log_ratio   	= true;
 			eff_LLPdisplacement.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
 //			eff_LLPdisplacement.SetSelectiveCuts("MC", Form("eventHT > %s && ( (jet0_isMatchedTo == 0 && jet0_Pt >= %s) || (jet1_isMatchedTo == 0 && jet1_Pt >= %s) || (jet2_isMatchedTo == 0 && jet2_Pt >= %s) ) ", event_HT[i].c_str(), jet_E[i].c_str(), jet_E[i].c_str(), jet_E[i].c_str() ) ); // make sure that LLP 0 is matched to jet, and cut on the jet pT
-			eff_LLPdisplacement.SetSelectiveCuts("MC", Form("eventHT > %s && perJet_Pt >= %s ", event_HT[i].c_str(), jet_E[i].c_str() ) ); // cut on the jet pT
+			eff_LLPdisplacement.SetSelectiveCuts("MC", Form("eventHT > %s && perJet_Pt >= %s && perJet_MatchedLLP_DecayR < 300", event_HT[i].c_str(), jet_E[i].c_str() ) ); // cut on the jet pT
 			eff_LLPdisplacement.SetComparisonCuts({Cut_None, Cut_HLTpassed1, Cut_AnyLLP_HLT}); 
 			// eff_LLPdisplacement.colors = { kWhite, kOrange, kGreen+2 }; // to just see trigger efficiency 
 			eff_LLPdisplacement.colors = { kBlack, kAzure+7, kViolet+4 };
@@ -85,13 +92,15 @@ void MiniTuplePlotter_HLT_Effs(){
 		class MiniTuplePlotter plotter_HLTeffMC( filetags[key], path );
 //		plotter_HLTeffMC.SetPlots({P_jet0_E, P_jet0_Pt, P_jet0_Eta, P_jet0_Phi, P_eventHT});
 		plotter_HLTeffMC.SetPlots({P_perJet_E, P_perJet_Pt, P_perJet_Eta, P_perJet_Phi, P_eventHT});
-		plotter_HLTeffMC.SetTreeName( "PerJet_LLPmatched" ); // "NoSel" ); // "PerJet_LLPmatched"
+//		plotter_HLTeffMC.SetTreeName( "NoSel" ); 
+		plotter_HLTeffMC.SetTreeName( "PerJet_LLPmatched" );
 		plotter_HLTeffMC.SetOutputFileTag("HLT_v3_MC_"+key);
 		plotter_HLTeffMC.SetOutputDirectory("HLT_Efficiencies");
 		plotter_HLTeffMC.plot_norm 			= false;
 		plotter_HLTeffMC.plot_log_ratio   	= true;
 		plotter_HLTeffMC.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
-		plotter_HLTeffMC.SetSelectiveCuts("MC", Cut_matchedLLPinHCAL); // Cut_LLPinHCAL123_Jet0); // Cut_matchedLLPinHCAL);		// region for LLP decay, and require LLP is matched to jet 0
+//		plotter_HLTeffMC.SetSelectiveCuts("MC", Cut_LLPinHCAL123_Jet0);
+		plotter_HLTeffMC.SetSelectiveCuts("MC", Cut_matchedLLPinHCAL34);		// region for LLP decay, and require LLP is matched to jet 0
 		plotter_HLTeffMC.SetComparisonCuts({Cut_None, Cut_HLTpassed1, Cut_AnyLLP_HLT}); 
 		plotter_HLTeffMC.colors = { kBlack, kAzure+7, kViolet+4 };
 		plotter_HLTeffMC.SetLegendNames({"No cuts", "Monitoring HLT passed", "LLP HLT passed"});

--- a/MiniTuplePlotter/Gillian/MiniTuplePlotter_HLT_Effs.C
+++ b/MiniTuplePlotter/Gillian/MiniTuplePlotter_HLT_Effs.C
@@ -77,7 +77,7 @@ void MiniTuplePlotter_HLT_Effs(){
 			eff_LLPdisplacement.SetOutputDirectory("HLT_Efficiencies");
 			eff_LLPdisplacement.plot_norm 			= false;
 			eff_LLPdisplacement.plot_log_ratio   	= true;
-			eff_LLPdisplacement.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
+			eff_LLPdisplacement.SetLegendPosition( 0.15, 0.95, 0.43, 1.13 );
 //			eff_LLPdisplacement.SetSelectiveCuts("MC", Form("eventHT > %s && ( (jet0_isMatchedTo == 0 && jet0_Pt >= %s) || (jet1_isMatchedTo == 0 && jet1_Pt >= %s) || (jet2_isMatchedTo == 0 && jet2_Pt >= %s) ) ", event_HT[i].c_str(), jet_E[i].c_str(), jet_E[i].c_str(), jet_E[i].c_str() ) ); // make sure that LLP 0 is matched to jet, and cut on the jet pT
 			eff_LLPdisplacement.SetSelectiveCuts("MC", Form("eventHT > %s && perJet_Pt >= %s && perJet_MatchedLLP_DecayR < 300", event_HT[i].c_str(), jet_E[i].c_str() ) ); // cut on the jet pT
 			eff_LLPdisplacement.SetComparisonCuts({Cut_None, Cut_HLTpassed1, Cut_AnyLLP_HLT}); 
@@ -107,6 +107,7 @@ void MiniTuplePlotter_HLT_Effs(){
 			plotter_HLTeffMC.plot_norm 			= false;
 			plotter_HLTeffMC.plot_log_ratio   	= true;
 			plotter_HLTeffMC.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 ); // works when efficiency legend uses -0.45 for x (upper left) or -0.3 for y (middle right)
+			if (key == "LLP350_80_ctau500mm") plotter_HLTeffMC.SetLegendPosition( 0.6, 0.85, 0.88, 1.03 );
 			plotter_HLTeffMC.SetVariableBins( variable_bins[i] );
 	//		plotter_HLTeffMC.SetSelectiveCuts("MC", Cut_LLPinHCAL123_Jet0);
 			plotter_HLTeffMC.SetSelectiveCuts("MC", Cut_matchedLLPinHCAL34);		// region for LLP decay, and require LLP is matched to jet 0

--- a/MiniTuplePlotter/Gillian/MiniTuplePlotter_HLT_Effs.C
+++ b/MiniTuplePlotter/Gillian/MiniTuplePlotter_HLT_Effs.C
@@ -14,16 +14,20 @@ void MiniTuplePlotter_HLT_Effs(){
 	// vector<string> filetags_MC = 	{ "v1.2_MCsignal_500k_2023_08_31" };
 
 	string path_v3 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.0/minituple_";
-	string path = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.6/minituple_";
+	string path = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/minituple_";
 
 	map<string,vector<string>> filetags;
-	// filetags["LLP125"]	= { "v3.0_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2023_11_23"};
+	filetags["LLP125"]	= { "v3.0_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2023_11_23"};
 	// filetags["LLP350"]	= { "v3.0_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2023_11_29"};
-	filetags["LLP125_mX15"]	= { "v3.6_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_02_TEST"};
-	filetags["LLP350_mX80"]	= { "v3.6_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_02_TEST"};
-	filetags["LLP125"]		= { "v3.6_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_03_02_batch2"};
-	filetags["LLP250"]		= { "v3.6_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_03_02_batch2"};
-	filetags["LLP350"]		= { "v3.6_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_03_02_batch2"};
+
+	filetags["LLP350"]	= { "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST"};
+	filetags["LLP125_50"]	= { "v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau10000_13p6TeV_2024_05_09"};
+	
+	// filetags["LLP125_mX15"]	= { "v3.6_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_02_TEST"};
+	// filetags["LLP350_mX80"]	= { "v3.6_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_02_TEST"};
+	// filetags["LLP125"]		= { "v3.6_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_03_02_batch2"};
+	// filetags["LLP250"]		= { "v3.6_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_03_02_batch2"};
+	// filetags["LLP350"]		= { "v3.6_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_03_02_batch2"};
 
 	vector<string> filetags_LLP125	= { "v3.0_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2023_11_23"};
 	vector<string> filetags_LLP350	= { "v3.0_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2023_11_29"};
@@ -40,10 +44,11 @@ void MiniTuplePlotter_HLT_Effs(){
 
 	// to do -- make a new version that is jet based!
 
-	vector<string> filetag_keys_to_loop = {"LLP125", "LLP250", "LLP350", "LLP125_mX15", "LLP350_mX80"};
+	// vector<string> filetag_keys_to_loop = {"LLP125", "LLP250", "LLP350", "LLP125_mX15", "LLP350_mX80"};
+	vector<string> filetag_keys_to_loop = {"LLP350", "LLP125_50"};
 
-	vector<string> jet_E = {"60", "100"};
-	vector<string> event_HT = {"200", "170"};
+	vector<string> jet_E = {"60"}; //{"60", "100"};
+	vector<string> event_HT = {"200"}; // {"200", "170"};
 
 	for( auto key: filetag_keys_to_loop){
 
@@ -64,8 +69,10 @@ void MiniTuplePlotter_HLT_Effs(){
 			eff_LLPdisplacement.SetSelectiveCuts("MC", Form("eventHT > %s && ( (jet0_isMatchedTo == 0 && jet0_Pt >= %s) || (jet1_isMatchedTo == 0 && jet1_Pt >= %s) || (jet2_isMatchedTo == 0 && jet2_Pt >= %s) ) ", event_HT[i].c_str(), jet_E[i].c_str(), jet_E[i].c_str(), jet_E[i].c_str() ) ); // make sure that LLP 0 is matched to jet, and cut on the jet pT
 //			eff_LLPdisplacement.SetSelectiveCuts("MC", Form("eventHT > %s && perJet_Pt >= %s ", event_HT[i].c_str(), jet_E[i].c_str() ) ); // cut on the jet pT
 			eff_LLPdisplacement.SetComparisonCuts({Cut_None, Cut_HLTpassed1, Cut_AnyLLP_HLT}); 
+			// eff_LLPdisplacement.colors = { kWhite, kOrange, kGreen+2 }; // to just see trigger efficiency 
 			eff_LLPdisplacement.SetLegendNames({"No cuts", "Monitoring HLT passed", "LLP HLT passed"});
-			eff_LLPdisplacement.Plot("ratio");
+			// eff_LLPdisplacement.Plot("ratio");
+			eff_LLPdisplacement.Plot("efficiency");
 			eff_LLPdisplacement.ClearFileTrees(); 														// reset, and cut on each HLT group
 			eff_LLPdisplacement.SetOutputFileTag("HLT_v3_MC_"+key+"_jetE"+jet_E[i]+"_HLTsplit");
 			eff_LLPdisplacement.SetComparisonCuts({Cut_HLTpassed1, Cut_AnyLLP_HLT, Cut_HLTpassed2, Cut_HLTpassed9, Cut_HLTpassed5, Cut_HLTpassed11}); 
@@ -86,7 +93,8 @@ void MiniTuplePlotter_HLT_Effs(){
 		plotter_HLTeffMC.SetSelectiveCuts("MC", Cut_LLPinHCAL123_Jet0); // Cut_matchedLLPinHCAL);		// region for LLP decay, and require LLP is matched to jet 0
 		plotter_HLTeffMC.SetComparisonCuts({Cut_None, Cut_HLTpassed1, Cut_AnyLLP_HLT}); 
 		plotter_HLTeffMC.SetLegendNames({"No cuts", "Monitoring HLT passed", "LLP HLT passed"});
-		plotter_HLTeffMC.Plot("ratio");
+		// plotter_HLTeffMC.Plot("ratio");
+		plotter_HLTeffMC.Plot("efficiency");
 		plotter_HLTeffMC.ClearFileTrees(); 																// reset, and cut on each HLT group.
 		plotter_HLTeffMC.SetOutputFileTag("HLT_v3_MC_"+key+"_HLTsplit");
 		plotter_HLTeffMC.SetComparisonCuts({Cut_HLTpassed1, Cut_AnyLLP_HLT, Cut_HLTpassed2, Cut_HLTpassed9, Cut_HLTpassed5, Cut_HLTpassed11}); 

--- a/MiniTuplePlotter/Gillian/MiniTuplePlotter_HLT_Effs.C
+++ b/MiniTuplePlotter/Gillian/MiniTuplePlotter_HLT_Effs.C
@@ -14,7 +14,7 @@ void MiniTuplePlotter_HLT_Effs(){
 	// vector<string> filetags_MC = 	{ "v1.2_MCsignal_500k_2023_08_31" };
 
 	string path_v3 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.0/minituple_";
-	string path = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/minituple_";
+	string path = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_";
 
 	map<string,vector<string>> filetags;
 	filetags["LLP125"]	= { "v3.0_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2023_11_23"};
@@ -45,7 +45,7 @@ void MiniTuplePlotter_HLT_Effs(){
 	// to do -- make a new version that is jet based!
 
 	// vector<string> filetag_keys_to_loop = {"LLP125", "LLP250", "LLP350", "LLP125_mX15", "LLP350_mX80"};
-	vector<string> filetag_keys_to_loop = {"LLP350", "LLP125_50"};
+	vector<string> filetag_keys_to_loop = {"LLP350"}; //, "LLP125_50"};
 
 	vector<string> jet_E = {"60"}; //{"60", "100"};
 	vector<string> event_HT = {"200"}; // {"200", "170"};
@@ -56,25 +56,26 @@ void MiniTuplePlotter_HLT_Effs(){
 
 			// with a jet pT cut, plot efficiency vs LLP displacement in R, Z, eta, travel time
 			class MiniTuplePlotter eff_LLPdisplacement( filetags[key], path );
-			eff_LLPdisplacement.SetPlots({P_LLP0_DecayR, P_LLP0_DecayZ, P_LLP0_Eta, P_LLP0_TravelTime});
-//			eff_LLPdisplacement.SetPlots({P_perJet_MatchedLLP_DecayR, P_perJet_MatchedLLP_DecayZ, P_perJet_MatchedLLP_Eta, P_perJet_MatchedLLP_TravelTime});
-//			eff_LLPdisplacement.SetPlots({P_perJet_MatchedLLP_DecayR, P_perJet_MatchedLLP_Eta});
-			eff_LLPdisplacement.SetTreeName( "NoSel" );
-//			eff_LLPdisplacement.SetTreeName( "PerJet_LLPmatched" );
+//			eff_LLPdisplacement.SetPlots({P_LLP0_DecayR, P_LLP0_DecayZ, P_LLP0_Eta, P_LLP0_TravelTime});
+			eff_LLPdisplacement.SetPlots({P_perJet_MatchedLLP_DecayR, P_perJet_MatchedLLP_DecayZ, P_perJet_MatchedLLP_Eta, P_perJet_MatchedLLP_TravelTime});
+//			eff_LLPdisplacement.SetTreeName( "NoSel" );
+			eff_LLPdisplacement.SetTreeName( "PerJet_LLPmatched" );
 			eff_LLPdisplacement.SetOutputFileTag("HLT_v3_MC_"+key+"_jetE"+jet_E[i]);
 			eff_LLPdisplacement.SetOutputDirectory("HLT_Efficiencies");
 			eff_LLPdisplacement.plot_norm 			= false;
 			eff_LLPdisplacement.plot_log_ratio   	= true;
 			eff_LLPdisplacement.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
-			eff_LLPdisplacement.SetSelectiveCuts("MC", Form("eventHT > %s && ( (jet0_isMatchedTo == 0 && jet0_Pt >= %s) || (jet1_isMatchedTo == 0 && jet1_Pt >= %s) || (jet2_isMatchedTo == 0 && jet2_Pt >= %s) ) ", event_HT[i].c_str(), jet_E[i].c_str(), jet_E[i].c_str(), jet_E[i].c_str() ) ); // make sure that LLP 0 is matched to jet, and cut on the jet pT
-//			eff_LLPdisplacement.SetSelectiveCuts("MC", Form("eventHT > %s && perJet_Pt >= %s ", event_HT[i].c_str(), jet_E[i].c_str() ) ); // cut on the jet pT
+//			eff_LLPdisplacement.SetSelectiveCuts("MC", Form("eventHT > %s && ( (jet0_isMatchedTo == 0 && jet0_Pt >= %s) || (jet1_isMatchedTo == 0 && jet1_Pt >= %s) || (jet2_isMatchedTo == 0 && jet2_Pt >= %s) ) ", event_HT[i].c_str(), jet_E[i].c_str(), jet_E[i].c_str(), jet_E[i].c_str() ) ); // make sure that LLP 0 is matched to jet, and cut on the jet pT
+			eff_LLPdisplacement.SetSelectiveCuts("MC", Form("eventHT > %s && perJet_Pt >= %s ", event_HT[i].c_str(), jet_E[i].c_str() ) ); // cut on the jet pT
 			eff_LLPdisplacement.SetComparisonCuts({Cut_None, Cut_HLTpassed1, Cut_AnyLLP_HLT}); 
 			// eff_LLPdisplacement.colors = { kWhite, kOrange, kGreen+2 }; // to just see trigger efficiency 
+			eff_LLPdisplacement.colors = { kBlack, kAzure+7, kViolet+4 };
 			eff_LLPdisplacement.SetLegendNames({"No cuts", "Monitoring HLT passed", "LLP HLT passed"});
 			// eff_LLPdisplacement.Plot("ratio");
 			eff_LLPdisplacement.Plot("efficiency");
 			eff_LLPdisplacement.ClearFileTrees(); 														// reset, and cut on each HLT group
 			eff_LLPdisplacement.SetOutputFileTag("HLT_v3_MC_"+key+"_jetE"+jet_E[i]+"_HLTsplit");
+			eff_LLPdisplacement.colors = { kBlack, kOrange, kGreen+2, kAzure+7, kBlue-4, kViolet+4, kMagenta-7, kRed  };
 			eff_LLPdisplacement.SetComparisonCuts({Cut_HLTpassed1, Cut_AnyLLP_HLT, Cut_HLTpassed2, Cut_HLTpassed9, Cut_HLTpassed5, Cut_HLTpassed11}); 
 			eff_LLPdisplacement.SetLegendNames({"Monitoring HLT passed", "LLP HLT passed", "Displaced dijet, <=1 prompt track", "Displaced dijet, <=2 prompt tracks", "Displaced dijet, 1 displaced track", "Delayed jet, ECAL jet timing"});
 			eff_LLPdisplacement.Plot("ratio");
@@ -82,21 +83,23 @@ void MiniTuplePlotter_HLT_Effs(){
 
 		// cut on LLP displacement, plot efficiency vs jet pT, E, eta, phi, event HTT
 		class MiniTuplePlotter plotter_HLTeffMC( filetags[key], path );
-		plotter_HLTeffMC.SetPlots({P_jet0_E, P_jet0_Pt, P_jet0_Eta, P_jet0_Phi, P_eventHT});
-//		plotter_HLTeffMC.SetPlots({P_perJet_E, P_perJet_Pt, P_perJet_Eta, P_perJet_Phi, P_eventHT});
-		plotter_HLTeffMC.SetTreeName( "NoSel" ); // "PerJet_LLPmatched"
+//		plotter_HLTeffMC.SetPlots({P_jet0_E, P_jet0_Pt, P_jet0_Eta, P_jet0_Phi, P_eventHT});
+		plotter_HLTeffMC.SetPlots({P_perJet_E, P_perJet_Pt, P_perJet_Eta, P_perJet_Phi, P_eventHT});
+		plotter_HLTeffMC.SetTreeName( "PerJet_LLPmatched" ); // "NoSel" ); // "PerJet_LLPmatched"
 		plotter_HLTeffMC.SetOutputFileTag("HLT_v3_MC_"+key);
 		plotter_HLTeffMC.SetOutputDirectory("HLT_Efficiencies");
 		plotter_HLTeffMC.plot_norm 			= false;
 		plotter_HLTeffMC.plot_log_ratio   	= true;
 		plotter_HLTeffMC.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
-		plotter_HLTeffMC.SetSelectiveCuts("MC", Cut_LLPinHCAL123_Jet0); // Cut_matchedLLPinHCAL);		// region for LLP decay, and require LLP is matched to jet 0
+		plotter_HLTeffMC.SetSelectiveCuts("MC", Cut_matchedLLPinHCAL); // Cut_LLPinHCAL123_Jet0); // Cut_matchedLLPinHCAL);		// region for LLP decay, and require LLP is matched to jet 0
 		plotter_HLTeffMC.SetComparisonCuts({Cut_None, Cut_HLTpassed1, Cut_AnyLLP_HLT}); 
+		plotter_HLTeffMC.colors = { kBlack, kAzure+7, kViolet+4 };
 		plotter_HLTeffMC.SetLegendNames({"No cuts", "Monitoring HLT passed", "LLP HLT passed"});
 		// plotter_HLTeffMC.Plot("ratio");
 		plotter_HLTeffMC.Plot("efficiency");
 		plotter_HLTeffMC.ClearFileTrees(); 																// reset, and cut on each HLT group.
 		plotter_HLTeffMC.SetOutputFileTag("HLT_v3_MC_"+key+"_HLTsplit");
+		plotter_HLTeffMC.colors = { kBlack, kOrange, kGreen+2, kAzure+7, kBlue-4, kViolet+4, kMagenta-7, kRed  };
 		plotter_HLTeffMC.SetComparisonCuts({Cut_HLTpassed1, Cut_AnyLLP_HLT, Cut_HLTpassed2, Cut_HLTpassed9, Cut_HLTpassed5, Cut_HLTpassed11}); 
 		plotter_HLTeffMC.SetLegendNames({"Monitoring HLT passed", "LLP HLT passed", "Displaced dijet, <=1 prompt track", "Displaced dijet, <=2 prompt tracks", "Displaced dijet, 1 displaced track", "Delayed jet, ECAL jet timing"});
 		plotter_HLTeffMC.Plot("ratio");

--- a/MiniTuplePlotter/MiniTuplePlotter.h
+++ b/MiniTuplePlotter/MiniTuplePlotter.h
@@ -849,7 +849,8 @@ public :
 				myCanvas->cd(2);
 				// need to get the first hist, this will be the denominator for the efficiency plot when listed first in compare cuts (h_total)
 				int i = 0;
-				TLegend* leg  = new TLegend(legx1-0.45,legy1,legx2-0.45,legy2);
+				// TLegend* leg  = new TLegend(legx1-0.45,legy1,legx2-0.45,legy2);
+				TLegend* leg  = new TLegend(legx1,legy1-0.3,legx2,legy2-0.3);
 				string denom_hist_tag = "";
 				for( auto hist_tag: hist_tags ){
 					// string hist_tag = Form( "%s "+GetBetterCutTitle( selective_cuts[filetag_treename] )+" "+GetBetterCutTitle( cut_compare ), filetag_treename.c_str() );

--- a/MiniTuplePlotter/MiniTuplePlotter.h
+++ b/MiniTuplePlotter/MiniTuplePlotter.h
@@ -863,7 +863,7 @@ public :
 						if(TEfficiency::CheckConsistency(*h_pass, *h_total)) {
 							pEff = new TEfficiency(*h_pass, *h_total);
 							string label_y = "Efficiency";
-							pEff->SetTitle(Form("HCAL LLP Trigger Efficiencies; %s; %s", PlotParams_temp.label_x.c_str(), label_y.c_str()));
+							pEff->SetTitle(Form("; %s; %s", PlotParams_temp.label_x.c_str(), label_y.c_str())); // HCAL LLP Trigger Efficiencies
 							pEff->SetLineColor( colors[i] );
 							pEff->SetLineWidth(3.);
 							if (i == 1) pEff->Draw();
@@ -873,7 +873,10 @@ public :
 
 							leg->AddEntry(pEff, Form("%s", legend_names.at(i).c_str() ) );
 
-							if (i == size(hist_tags)-1 ) leg->Draw();
+							if (i == size(hist_tags)-1 ) {
+								leg->Draw();
+								StampCMS( "Simulation Preliminary", 140., 0.14, 0.92, 0.045, 2 ); // 0 means no energy, 1 means sqrt s, 2 means (13.6 TeV) (should we have this for simulation?)
+							}
 						}
 					}
 					i += 1;

--- a/MiniTuplePlotter/MiniTuplePlotter.h
+++ b/MiniTuplePlotter/MiniTuplePlotter.h
@@ -240,7 +240,6 @@ public :
 		filetags_treenames.clear();
 	}
 
-
 	// =====================================================================================
 	// Output File Info and Legend Format (Including Displaying Fit Info) 
 	// =====================================================================================
@@ -446,7 +445,6 @@ public :
 		legy1 = legy1_temp;
 		legx2 = legx2_temp;
 		legy2 = legy2_temp;
-
 	}
 
 	// -------------------------------------------------------------------------------------
@@ -686,7 +684,7 @@ public :
 		if( debug) cout<<"MiniTuplePlotter::GetStackHist()"<<endl;		
 
 		string label_y = "Events / Bin";
-		if( plot_norm ) label_y = "A.U.";
+		if( plot_norm ) label_y = "Normalized Fraction of Events"; //"A.U.";
 		if( plot_cdf  ) label_y = "CDF";
 		if( plot_reverse_cdf ) label_y = "Reverse CDF";
 
@@ -751,7 +749,7 @@ public :
 			filetag_treename_divisor = hist_tags[0];
 
 		// string label_y = Form( "Hist / %s", filetag_treename_divisor.c_str() );
-		string label_y = "Ratio"; // testing to simplify ratio y axis name
+		string label_y = "Ratio"; // "Efficiency"; // testing to simplify ratio y axis name
 		if( plot_norm ) label_y += " (norm)";
 
 		THStack* hs = new THStack(Form( "hs_%s", myPlotParams.hist_name.c_str() ), Form(" ; %s; %s", myPlotParams.label_x.c_str(), label_y.c_str() ));
@@ -779,8 +777,8 @@ public :
 			else if( plot_reverse_cdf )
 				h = GetReverseCDF( h ); 	
 
-			h->SetMaximum( 2. );
-			if( plot_log_ratio ) h->SetMaximum( 100. );
+			h->SetMaximum( 1.1 );
+			if( plot_log_ratio ) h->SetMaximum( 4. );
 
 			h->Divide( h_divisor );
 			h->SetLineColor( colors[i] );
@@ -819,7 +817,11 @@ public :
 
 			THStack* hs = GetStackHist( hists, PlotParams_temp );
 			myCanvas->cd(1);
-			hs->Draw("nostack"); 
+			hs->Draw("nostack"); //, hist"); //, e1"); 
+			gStyle->SetHistTopMargin(0);
+			//hs->SetMinimum(1);
+			//hs->SetMaximum(500000);
+			//gPad->Update();
 			//hs->Draw(); // stacked histograms, with points for each (not bar)
 			//hs->Draw("bar"); // stacked histograms, with bars for each. Use with "h->SetFillColor( colors[i] )"
 
@@ -834,8 +836,49 @@ public :
 				if( plot_log_ratio ) gPad->SetLogy(); 	
 				if( plot_log_x ) gPad->SetLogx(); 
 				THStack* hs_ratio = GetStackRatio( hists, PlotParams_temp, filetag_treename_divisor );	
-				hs_ratio->Draw("nostack");
+				hs_ratio->Draw("nostack"); //, hist"); // bug, not using uncertainty propagation, seems to try to do a per event sqrt N, errors 0-2
+				//hs_ratio->SetMinimum(0.0001);
+				//hs_ratio->SetMaximum(0.1);
+				hs_ratio->SetMaximum(1.);
+				//gPad->Update();
 				myCanvas->cd(1);
+			}
+
+			// put efficiency TEff code here?
+			if( plot_type == "efficiency" ){
+				myCanvas->cd(2);
+				// need to get the first hist, this will be the denominator for the efficiency plot when listed first in compare cuts (h_total)
+				int i = 0;
+				TLegend* leg  = new TLegend(legx1-0.45,legy1,legx2-0.45,legy2);
+				string denom_hist_tag = "";
+				for( auto hist_tag: hist_tags ){
+					// string hist_tag = Form( "%s "+GetBetterCutTitle( selective_cuts[filetag_treename] )+" "+GetBetterCutTitle( cut_compare ), filetag_treename.c_str() );
+					if (i == 0) denom_hist_tag = hist_tag;
+					// cout << denom_hist_tag << " = denom tag and current tag = " << hist_tag << endl;
+					TH1F *h_total = (TH1F*)hists[denom_hist_tag]->Clone();
+					if (i > 0) {
+						TH1F *h_pass = (TH1F*)hists[hist_tag]->Clone();
+						TEfficiency* pEff = 0;
+ 						// h_pass and h_total are valid and consistent histograms
+						if(TEfficiency::CheckConsistency(*h_pass, *h_total)) {
+							pEff = new TEfficiency(*h_pass, *h_total);
+							string label_y = "Efficiency";
+							pEff->SetTitle(Form("HCAL LLP Trigger Efficiencies; %s; %s", PlotParams_temp.label_x.c_str(), label_y.c_str()));
+							pEff->SetLineColor( colors[i] );
+							pEff->SetLineWidth(3.);
+							if (i == 1) pEff->Draw();
+							if (i > 1) pEff->Draw("same");
+							gPad->Update();
+							pEff->GetPaintedGraph()->GetYaxis()->SetRangeUser(0,1.);
+
+							leg->AddEntry(pEff, Form("%s", legend_names.at(i).c_str() ) );
+
+							if (i == size(hist_tags)-1 ) leg->Draw();
+						}
+					}
+					i += 1;
+					// want to use ranges already defined in PlotParams! 
+				}
 			}
 
 			myCanvas->cd(1);

--- a/MiniTuplePlotter/PlotFunctions.h
+++ b/MiniTuplePlotter/PlotFunctions.h
@@ -12,6 +12,7 @@
 #include "THStack.h"
 #include "TLegend.h"
 #include "TString.h"
+#include "TEfficiency.h"
 #include <iostream>
 #include <iomanip>
 
@@ -54,7 +55,7 @@ void SetStyle(){
 }
 
 // -------------------------------------------------------------------------------------
-void StampCMS( const std::string & approvaltext = "Internal", float lumi=140., float x=0.14, float y=0.84, float textsize=0.045) {
+void StampCMS( const std::string & approvaltext = "Internal", float lumi=140., float x=0.14, float y=0.84, float textsize=0.045, float energy=1) {
   // Usage:  StampCMS("Internal", 126.5, 0.12, 0.75);
   
   textsize = 0.045;
@@ -72,14 +73,25 @@ void StampCMS( const std::string & approvaltext = "Internal", float lumi=140., f
   label_approvaltext.SetTextSize(textsize*0.85);
   label_approvaltext.DrawLatex( x+0.075, y, approvaltext.c_str() ); 
 
-  TLatex label_energylumi; 
-  label_energylumi.SetNDC();
-  label_energylumi.SetTextFont(42);
-  label_energylumi.SetTextColor(1);
-  label_energylumi.SetTextSize(textsize*0.65 );
-  label_energylumi.DrawLatex( x, y-.035, "#sqrt{s} = 13.6 TeV" ); // Just energy for now...
-  //label_energylumi.DrawLatex( x, y-.08, Form("L = %.1f fb^{-1}", lumi) );
-  //label_energylumi.DrawLatex( x+.01, y-.2, "SF = #frac{N_{SR}}{N_{CR}} = 0.88" );
+  if (energy == 1) {
+	TLatex label_energylumi; 
+	label_energylumi.SetNDC();
+	label_energylumi.SetTextFont(42);
+	label_energylumi.SetTextColor(1);
+	label_energylumi.SetTextSize(textsize*0.65 );
+	label_energylumi.DrawLatex( x, y-.04, "#sqrt{s} = 13.6 TeV" ); // Just energy for now...
+	//label_energylumi.DrawLatex( x, y-.08, Form("L = %.1f fb^{-1}", lumi) );
+	//label_energylumi.DrawLatex( x+.01, y-.2, "SF = #frac{N_{SR}}{N_{CR}} = 0.88" );
+  }
+
+  if (energy == 2) {
+	TLatex label_energylumi; 
+	label_energylumi.SetNDC();
+	label_energylumi.SetTextFont(42);
+	label_energylumi.SetTextColor(1);
+	label_energylumi.SetTextSize(textsize*0.65 );
+	label_energylumi.DrawLatex( x+0.65, y, "(13.6 TeV)" );
+  }
 
 }
 

--- a/MiniTuplePlotter/PlotParams.h
+++ b/MiniTuplePlotter/PlotParams.h
@@ -207,7 +207,7 @@ PlotParams P_jet1_NeutralOverChargedHad = {"jet1_NeutralHadEFrac/jet0_ChargedHad
 PlotParams P_met_Pt						= {"met_Pt", "MET p_{T}", "p_{T} [GeV]", 0, 400 };
 PlotParams P_met_Phi					= {"met_Phi", "MET #phi", "#phi", -3.2, 3.2 };
 PlotParams P_met_SumEt					= {"met_SumEt", "MET Sum E_{T}", "E_{T} [GeV]", 0, 5000 };
-PlotParams P_eventHT					= {"eventHT", "Event HT", "HT [GeV]", 0, 2000 };
+PlotParams P_eventHT					= {"eventHT", "Event HT", "HT [GeV]", 0, 1200 };
 
 // --------------------------------------------------------------------- //
 // LLP variables 

--- a/MiniTuplePlotter/PlotParams.h
+++ b/MiniTuplePlotter/PlotParams.h
@@ -33,8 +33,8 @@ struct Hist1_Hist2{
 // Leading Jet 
 // kinematics
 PlotParams P_jet0_RechitN				= {"jet0_RechitN", "Number of HCAL RecHits", "N^{HCAL}_{RecHits}", 0, 60 };
-PlotParams P_jet0_E						= {"jet0_E", "Leading Jet Energy", "Jet E [GeV]", 0, 250 };
-PlotParams P_jet0_Pt					= {"jet0_Pt", "Leading Jet p_{T}", "Jet p_{T} [GeV]", 0, 250 };
+PlotParams P_jet0_E						= {"jet0_E", "Leading Jet Energy", "Jet E [GeV]", 0, 300 };
+PlotParams P_jet0_Pt					= {"jet0_Pt", "Leading Jet p_{T}", "Jet p_{T} [GeV]", 0, 300 };
 PlotParams P_jet0_Eta					= {"jet0_Eta", "Leading Jet #eta", "Jet #eta", -1.5, 1.5 };
 PlotParams P_jet0_Phi					= {"jet0_Phi", "Leading Jet #phi", "Jet #phi", -3.2, 3.2 };
 PlotParams P_jet0_Mass					= {"jet0_Mass", "Leading Jet Mass", "Jet Mass", 0, 40 };
@@ -218,10 +218,10 @@ PlotParams P_LLP0_Pt					= {"LLP0_Pt", "LLP0 p_{T}", "p_{T} [GeV]", 0, 250 };
 PlotParams P_LLP0_E						= {"LLP0_E", "LLP0 Energy", "E [GeV]", 0, 250 };
 PlotParams P_LLP0_Beta					= {"LLP0_Beta", "LLP0 $beta", "$beta", 0, 250 };
 PlotParams P_LLP0_TravelTime			= {"LLP0_TravelTime", "LLP0 Travel Time", "Travel Time [ns]", 0, 25 };
-PlotParams P_LLP0_DecayR				= {"LLP0_DecayR", "LLP0 decay radius", "Decay R [cm]", 0, 350 };
+PlotParams P_LLP0_DecayR				= {"LLP0_DecayR", "LLP0 decay radius", "Decay R [cm]", 0, 300 };
 PlotParams P_LLP0_DecayX				= {"LLP0_DecayX", "LLP0 decay X position", "Decay X [cm]", -2000, 2000 };
 PlotParams P_LLP0_DecayY				= {"LLP0_DecayY", "LLP0 decay Y position", "Decay Y [cm]", -2000, 2000 };
-PlotParams P_LLP0_DecayZ				= {"LLP0_DecayZ", "LLP0 decay Z position", "Decay Z [cm]", -1000, 1000 };
+PlotParams P_LLP0_DecayZ				= {"LLP0_DecayZ", "LLP0 decay Z position", "Decay Z [cm]", -500, 500 };
 PlotParams P_LLP0_DecayT				= {"LLP0_DecayT", "LLP0 decay time", "Decay time [ns]", 0, 10 };
 PlotParams P_LLP0_DecayCtau				= {"LLP0_DecayCtau", "LLP0 c#tau", "c#tau [cm]", 0, 1000 };
 
@@ -256,7 +256,10 @@ PlotParams P_perJet_Eta					= {"perJet_Eta", "Jet #eta", "Jet #eta", -1.5, 1.5 }
 PlotParams P_perJet_Phi					= {"perJet_Phi", "Jet #phi", "Jet #phi", -3.2, 3.2 };
 PlotParams P_perJet_Mass				= {"perJet_Mass", "Jet Mass", "Jet Mass", 0, 40 };
 
-PlotParams P_perJet_NeutralHadEFrac			= {"perJet_NeutralHadEFrac", "Jet: Neutral Hadron Energy Fraction", "Neutral Hadron Energy Fraction", 0, 1.01 };
+PlotParams P_run						= {"run", "Run Number", "Run Number", 366000, 372000};
+PlotParams P_bdtscore_LLP350_MS80_perJet = {"bdtscore_LLP350_MS80_perJet", "BDT Score", "BDT (350, 80) Score", 0.99, 1};
+
+PlotParams P_perJet_NeutralHadEFrac			= {"perJet_NeutralHadEFrac", "Jet: Neutral Hadron Energy Fraction", "Neutral Hadron Energy Fraction", 0, 0.8 }; //1.01 };
 PlotParams P_perJet_ChargedHadEFrac			= {"perJet_ChargedHadEFrac", "Jet: Charged Hadron Energy Fraction", "Charged Hadron Energy Fraction", 0, 1.01 };
 PlotParams P_perJet_PhoEFrac				= {"perJet_PhoEFrac", "Jet: Photon Energy Fraction", "Photon Energy Fraction", 0, 1.01 };
 PlotParams P_perJet_EleEFrac				= {"perJet_EleEFrac", "Jet: Electron Energy Fraction", "Electron Energy Fraction", 0, 1.01 };

--- a/MiniTuplePlotter/RegionCuts.h
+++ b/MiniTuplePlotter/RegionCuts.h
@@ -192,18 +192,10 @@ TCut Cut_JetPt200 	= "jet0_Pt >= 200";
 
 
 // cuts for bins of BDT score
-TCut Cut_BDTscoreN 	    = "bdtscore_125GeV >= -1 && bdtscore_125GeV < 0";
-TCut Cut_BDTscorePt5 	= "bdtscore_125GeV >= 0 && bdtscore_125GeV < 0.5";
-TCut Cut_BDTscorePt9 	= "bdtscore_125GeV >= 0.5 && bdtscore_125GeV < 0.9";
-TCut Cut_BDTscorePt95 	= "bdtscore_125GeV >= 0.9 && bdtscore_125GeV < 0.95";
-TCut Cut_BDTscore1   	= "bdtscore_125GeV >= 0.95";
-
-TCut Cut_BDTscoreNPt99 	= "bdtscore_125GeV >= -1 && bdtscore_125GeV < -0.99";
-TCut Cut_BDTscoreNPt98 	= "bdtscore_125GeV >= -0.99 && bdtscore_125GeV < -0.98";
-TCut Cut_BDTscoreNPt95 	= "bdtscore_125GeV >= -0.98 && bdtscore_125GeV < -0.95";
-TCut Cut_BDTscore0   	= "bdtscore_125GeV >= -0.95 && bdtscore_125GeV < 0";
-TCut Cut_BDTscorePos   	= "bdtscore_125GeV >= 0";
-
+TCut Cut_BDTscorePt9    = "bdtscore_LLP350_MS80_perJet >= 0.9 && bdtscore_LLP350_MS80_perJet < 0.95"; // "bdtscore_125GeV >= -1 && bdtscore_125GeV < 0";
+TCut Cut_BDTscorePt95 	= "bdtscore_LLP350_MS80_perJet >= 0.95 && bdtscore_LLP350_MS80_perJet < 0.99";
+TCut Cut_BDTscorePt99 	= "bdtscore_LLP350_MS80_perJet >= 0.99 && bdtscore_LLP350_MS80_perJet < 0.999";
+TCut Cut_BDTscore1   	= "bdtscore_LLP350_MS80_perJet >= 0.999";
 
 // --------------------------------------------------------------------- //
 // ---------------------------- per jet cuts --------------------------- //

--- a/Run/Condor/condor_header.cmd
+++ b/Run/Condor/condor_header.cmd
@@ -4,10 +4,10 @@ should_transfer_files   = YES
 when_to_transfer_output = ON_EXIT_OR_EVICT
 notification   		    = never
 
-# Espresso: batch 1, microcentury: batch 2, longlunch: displaced jet, workday: 2023Bv1
+# Espresso: batch 1, microcentury: batch 2, longlunch: displaced jet LLP dataset, workday: 2023Bv1
 # +JobFlavour = "espresso" 
-+JobFlavour = "microcentury"
-# +JobFlavour = "longlunch"
+# +JobFlavour = "microcentury"
++JobFlavour = "longlunch"
 # +JobFlavour = "workday"
 
 # Output

--- a/Run/Condor/hadd_all.sh
+++ b/Run/Condor/hadd_all.sh
@@ -1,27 +1,35 @@
 #!/bin/bash
 
-# find-replace v3.7 -> vx
-# find-replace 2024_03_14 -> today's date
+# find-replace v3.8 -> vx
+# find-replace 2024_06_03 -> today's date
 
 echo "batch 1 and batch 2 of high LLP mass MC"
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_03_14_batch1.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP350_160_batch1_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_03_14_batch2.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP350_160_batch2_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_03_14_batch1.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP250_120_batch1_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_03_14_batch2.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP250_120_batch2_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_03_14_batch1.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP125_50_batch1_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_03_14_batch2.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP125_50_batch2_2024_03_14/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_06_03_batch1.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP350_160_batch1_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_13p6TeV_2024_06_03_batch2.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP350_160_batch2_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_06_03_batch1.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP250_120_batch1_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_13p6TeV_2024_06_03_batch2.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP250_120_batch2_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_06_03_batch1.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_50_batch1_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_06_03_batch2.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_50_batch2_2024_06_03/*.root
 
 echo "test and train of low LLP mass MC"
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP125_15_TEST_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TRAIN.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP125_15_TRAIN_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP350_80_TEST_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TRAIN.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP350_80_TRAIN_2024_03_14/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_06_03_TEST.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_15_TEST_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_06_03_TRAIN.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_15_TRAIN_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_06_03_TEST.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP350_80_TEST_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_06_03_TRAIN.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP350_80_TRAIN_2024_06_03/*.root
+
+echo "newest LLP MC mH = 125 samples"
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau10000_13p6TeV_2024_06_03.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_50_10m_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau10000_13p6TeV_2024_06_03.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_15_10m_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau3000_13p6TeV_2024_06_03.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_15_3m_2024_06_03/*.root
 
 echo "2023 displaced jet skim"
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLPskim_Run2023Bv1_2024_03_14.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Bv1_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLPskim_Run2023Cv1_2024_03_14.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Cv1_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLPskim_Run2023Cv2_2024_03_14.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Cv2_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLPskim_Run2023Cv3_2024_03_14.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Cv3_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLPskim_Run2023Cv4_2024_03_14.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Cv4_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLPskim_Run2023Dv1_2024_03_14.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Dv1_2024_03_14/*.root
-hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLPskim_Run2023Dv2_2024_03_14.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Dv2_2024_03_14/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLPskim_Run2023Bv1_2024_06_03.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Bv1_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLPskim_Run2023Cv1_2024_06_03.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Cv1_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLPskim_Run2023Cv2_2024_06_03.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Cv2_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLPskim_Run2023Cv3_2024_06_03.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Cv3_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLPskim_Run2023Cv4_2024_06_03.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Cv4_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLPskim_Run2023Dv1_2024_06_03.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Dv1_2024_06_03/*.root
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLPskim_Run2023Dv2_2024_06_03.root /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Dv2_2024_06_03/*.root
+
+echo "hadd all LLP skim"
+hadd -j /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLPskim_Run2023_HADD.root /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/minituple_v3.8_LLPskim_Run2023*.root

--- a/Run/Condor/submit_all.sh
+++ b/Run/Condor/submit_all.sh
@@ -2,42 +2,57 @@
 
 echo "submitting all MC"
 
+echo " "
 echo "Low mass LLP MC samples (train and test), 100 files total, 40-60 train-test split"
 echo " "
-python3 condor_run.py -i ../InputFiles_2024_01_19_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_ntuplesv3_TRAIN.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP125_15_TRAIN -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_125_lowMass_train
-python3 condor_run.py -i ../InputFiles_2024_01_19_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_ntuplesv3_TEST.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP125_15_TEST -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_125_lowMass_test 
+echo "mH = 125, mS = 15, cTau = 1m"
+python3 condor_run.py -i ../InputFiles_2024_01_19_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_ntuplesv3_TRAIN.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_15_TRAIN -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_125_lowMass_train
+python3 condor_run.py -i ../InputFiles_2024_01_19_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_ntuplesv3_TEST.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_15_TEST -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_125_lowMass_test 
 
-python3 condor_run.py -i ../InputFiles_2023_11_29_ggH_HTooSSTobbbb_MHH-350_MS-80_CTau500_ntuplesv3_TRAIN.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP350_80_TRAIN -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_350_lowMass_train
-python3 condor_run.py -i ../InputFiles_2023_11_29_ggH_HTooSSTobbbb_MHH-350_MS-80_CTau500_ntuplesv3_TEST.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP350_80_TEST -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_350_lowMass_test
+echo "mH = 350, mS = 80, cTau = 0.5m"
+python3 condor_run.py -i ../InputFiles_2023_11_29_ggH_HTooSSTobbbb_MHH-350_MS-80_CTau500_ntuplesv3_TRAIN.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP350_80_TRAIN -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_350_lowMass_train
+python3 condor_run.py -i ../InputFiles_2023_11_29_ggH_HTooSSTobbbb_MHH-350_MS-80_CTau500_ntuplesv3_TEST.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP350_80_TEST -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_350_lowMass_test
 
+echo " "
 echo "High mass LLP MC samples (train and test, batch 1 and 2), 200 files each"
 echo " "
+echo "mH = 125, mS = 50, cTau = 3m"
+python3 condor_run.py -i ../InputFiles_2024_02_12_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_50_batch1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_125_batch1
+python3 condor_run.py -i ../InputFiles_2024_02_12_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_batch2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_50_batch2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_125_batch2
+echo "mH = 250, mS = 120, cTau = 10m"
+python3 condor_run.py -i ../InputFiles_2024_02_12_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP250_120_batch1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_250_batch1
+python3 condor_run.py -i ../InputFiles_2024_02_12_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_batch2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP250_120_batch2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_250_batch2
+echo "mH = 350, mS = 160, cTau = 10m"
+python3 condor_run.py -i ../InputFiles_2024_02_12_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP350_160_batch1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_350_batch1
+python3 condor_run.py -i ../InputFiles_2024_02_12_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_batch2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP350_160_batch2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_350_batch2
+
+echo " "
+echo "Newest LLP MC samples, no train-test split yet. 100 files each"
+echo " "
 echo "mH = 125"
-python3 condor_run.py -i ../InputFiles_2024_02_12_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP125_50_batch1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_125_batch1
-python3 condor_run.py -i ../InputFiles_2024_02_12_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_batch2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP125_50_batch2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_125_batch2
-echo "mH = 250"
-python3 condor_run.py -i ../InputFiles_2024_02_12_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP250_120_batch1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_250_batch1
-python3 condor_run.py -i ../InputFiles_2024_02_12_ggH_HToSSTobbbb_MH-250_MS-120_CTau10000_batch2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP250_120_batch2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_250_batch2
-echo "mH = 350"
-python3 condor_run.py -i ../InputFiles_2024_02_12_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP350_160_batch1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_350_batch1
-python3 condor_run.py -i ../InputFiles_2024_02_12_ggH_HToSSTobbbb_MH-350_MS-160_CTau10000_batch2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_MC_LLP350_160_batch2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_350_batch2
+echo "mS = 50, cTau = 10m"
+python3 condor_run.py -i ../InputFiles_2024_05_09_ggH_HTooSSTobbbb_MH-125_MS50_CTau10000_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_50_10m -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_125_50_10m
+echo "mS = 15, cTau = 10m"
+python3 condor_run.py -i ../InputFiles_2024_05_13_ggH_HTooSSTobbbb_MH-125_MS15_CTau10000_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_15_10m -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_125_15_10m
+echo "mS = 15, cTau = 3m"
+python3 condor_run.py -i ../InputFiles_2024_05_13_ggH_HTooSSTobbbb_MH-125_MS15_CTau3000_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_MC_LLP125_15_3m -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f MC_LLP_125_15_3m
 
 echo "submitting 2023 displaced jet skim"
 echo " "
 echo "2023Bv1 -- 61 files"
-# python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023B-EXOLLPJetHCAL-PromptReco-v1_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Bv1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Bv1
+# python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023B-EXOLLPJetHCAL-PromptReco-v1_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Bv1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Bv1
 echo "2023Cv1 -- 922 files"
-# python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023C-EXOLLPJetHCAL-PromptReco-v1_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Cv1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv1
+# python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023C-EXOLLPJetHCAL-PromptReco-v1_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Cv1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv1
 echo "2023Cv2 -- 1304 files"
-# python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023C-EXOLLPJetHCAL-PromptReco-v2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Cv2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv2
+# python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023C-EXOLLPJetHCAL-PromptReco-v2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Cv2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv2
 echo "2023Cv3 -- 1484 files"
-# python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023C-EXOLLPJetHCAL-PromptReco-v3_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Cv3 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv3
+# python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023C-EXOLLPJetHCAL-PromptReco-v3_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Cv3 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv3
 echo "2023Cv4 -- 1855 files"
-# python3 condor_run.py -i ../InputFiles_2023_11_14_Run2023C-EXOLLPJetHCAL-PromptReco-v4_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Cv4 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv4
+# python3 condor_run.py -i ../InputFiles_2023_11_14_Run2023C-EXOLLPJetHCAL-PromptReco-v4_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Cv4 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv4
 echo "2023Dv1 -- 622 files"
-# python3 condor_run.py -i ../InputFiles_2023_11_14_Run2023D-EXOLLPJetHCAL-PromptReco-v1_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Dv1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Dv1
+# python3 condor_run.py -i ../InputFiles_2023_11_14_Run2023D-EXOLLPJetHCAL-PromptReco-v1_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Dv1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Dv1
 echo "2023Dv2 -- 83 files"
-# python3 condor_run.py -i ../InputFiles_2023_11_14_Run2023D-EXOLLPJetHCAL-PromptReco-v2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Dv2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Dv2
+# python3 condor_run.py -i ../InputFiles_2023_11_14_Run2023D-EXOLLPJetHCAL-PromptReco-v2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Dv2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Dv2
 # 6331 total
 
 # to check number of files in each directory:

--- a/Run/Condor/submit_skim.sh
+++ b/Run/Condor/submit_skim.sh
@@ -3,19 +3,19 @@
 echo "submitting 2023 displaced jet skim"
 echo " "
 echo "2023Bv1 -- 61 files"
-# python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023B-EXOLLPJetHCAL-PromptReco-v1_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Bv1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Bv1
+# python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023B-EXOLLPJetHCAL-PromptReco-v1_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Bv1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Bv1
 echo "2023Cv1 -- 922 files"
-python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023C-EXOLLPJetHCAL-PromptReco-v1_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Cv1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv1
+python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023C-EXOLLPJetHCAL-PromptReco-v1_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Cv1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv1
 echo "2023Cv2 -- 1304 files"
-python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023C-EXOLLPJetHCAL-PromptReco-v2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Cv2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv2
+python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023C-EXOLLPJetHCAL-PromptReco-v2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Cv2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv2
 echo "2023Cv3 -- 1484 files"
-python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023C-EXOLLPJetHCAL-PromptReco-v3_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Cv3 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv3
+python3 condor_run.py -i ../InputFiles_2023_11_08_Run2023C-EXOLLPJetHCAL-PromptReco-v3_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Cv3 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv3
 echo "2023Cv4 -- 1855 files"
-python3 condor_run.py -i ../InputFiles_2023_11_14_Run2023C-EXOLLPJetHCAL-PromptReco-v4_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Cv4 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv4
+python3 condor_run.py -i ../InputFiles_2023_11_14_Run2023C-EXOLLPJetHCAL-PromptReco-v4_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Cv4 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Cv4
 echo "2023Dv1 -- 622 files"
-python3 condor_run.py -i ../InputFiles_2023_11_14_Run2023D-EXOLLPJetHCAL-PromptReco-v1_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Dv1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Dv1
+python3 condor_run.py -i ../InputFiles_2023_11_14_Run2023D-EXOLLPJetHCAL-PromptReco-v1_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Dv1 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Dv1
 echo "2023Dv2 -- 83 files"
-python3 condor_run.py -i ../InputFiles_2023_11_14_Run2023D-EXOLLPJetHCAL-PromptReco-v2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.7_LLPskim_2023Dv2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Dv2
+python3 condor_run.py -i ../InputFiles_2023_11_14_Run2023D-EXOLLPJetHCAL-PromptReco-v2_ntuplesv3.txt -o /eos/user/g/gkopp/LLP_Analysis/output_minituples_v3.8_LLPskim_2023Dv2 -p /afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/Run/Condor/x509up_u101898 -b BDTWeightFiles.zip -f LLPskim_2023Dv2
 # 6331 total
 
 # to check number of files in each directory:

--- a/TMVAStudies/MakeMVAPerformancePlots_HLTcomp.C
+++ b/TMVAStudies/MakeMVAPerformancePlots_HLTcomp.C
@@ -470,7 +470,7 @@ void SetupPlots()
   GraphLabels.clear();
   PlotnameSpecific.clear();
 
-  legend = new TLegend(0.15,0.14,0.9,0.34);
+  legend = new TLegend(0.25,0.14,0.9,0.3);
   legend->SetTextSize(0.03);
   legend->SetBorderSize(0);
   legend->SetFillStyle(0);
@@ -491,10 +491,10 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
   //--------------------------------------------------------------------------------------------------------------
   // Histograms
   //==============================================================================================================  
-  TH1F *Signal_MVA350_80 = new TH1F(("Signal_MVA350_80"+label).c_str(), "LLP Signal ; MVA (BDT trained on 350, mX80) score for LLP signal ; Number of Events ",  5500, -1.1 , 1.1);
-  TH1F *Signal_MVA350_80_HLT = new TH1F(("Signal_MVA350_80_HLT"+label).c_str(), "LLP Signal ; MVA (BDT trained on 350, mX80) score for LLP signal (with HLT required) ; Number of Events ",  5500, -1.1 , 1.1);
+  TH1F *Signal_MVA350_80 = new TH1F(("Signal_MVA350_80"+label).c_str(), "LLP Signal ; MVA (BDT trained on 350, mX80) score for LLP signal ; Number of Events ",  22000, -1.1 , 1.1);
+  TH1F *Signal_MVA350_80_HLT = new TH1F(("Signal_MVA350_80_HLT"+label).c_str(), "LLP Signal ; MVA (BDT trained on 350, mX80) score for LLP signal (with HLT required) ; Number of Events ",  22000, -1.1 , 1.1);
 
-  TH1F *Background_MVA350_80 = new TH1F(("Background_MVA350_80"+label).c_str(), "W+Jets Background ; MVA (BDT trained on 350, mX80) score for W+jets background ; Number of Events ",  5500, -1.1 , 1.1);
+  TH1F *Background_MVA350_80 = new TH1F(("Background_MVA350_80"+label).c_str(), "W+Jets Background ; MVA (BDT trained on 350, mX80) score for W+jets background ; Number of Events ",  22000, -1.1 , 1.1);
 
   Double_t RealElectrons = 0;
   Double_t FakeElectrons = 0;
@@ -519,8 +519,11 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
   float radius_HBend = 295;
   float HBeta = 1.26;
 
+  TCut SafetySelection = "";
   TCut SignalSelection = "";
-  TCut HLT_Selection = "";
+  TCut HLT_Selection = "(HLT_HT200_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT240_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT280_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT270_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet60_DisplacedTrack == 1 || HLT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive == 1 || HLT_HT420_L1SingleLLPJet_DisplacedDijet60_Inclusive == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay1nsInclusive == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay2nsInclusive == 1 || HLT_L1SingleLLPJet == 1)";
+  TCut Anti_HLT_Selection = "(HLT_HT200_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 0 && HLT_HT240_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 0 && HLT_HT280_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 0 && HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 0 && HLT_HT200_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 0 && HLT_HT270_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 0 && HLT_HT200_L1SingleLLPJet_DisplacedDijet60_DisplacedTrack == 0 && HLT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive == 0 && HLT_HT420_L1SingleLLPJet_DisplacedDijet60_Inclusive == 0 && HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless == 0 && HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay1nsInclusive == 0 && HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless == 0 && HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay2nsInclusive == 0 && HLT_L1SingleLLPJet == 0)";
+  // TODO bug in v3.7 minituples that HLT results are not saved in jet trees, will be fixed in next version! 
   if (SigTree.find("PerJet") == std::string::npos) { // per event tree
     tree_sig->SetBranchAddress("LLP0_DecayR", &LLP0_DecayR);
     tree_sig->SetBranchAddress("LLP1_DecayR", &LLP1_DecayR);
@@ -529,8 +532,8 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
     tree_sig->SetBranchAddress("jet0_isMatchedTo", &jet0_isMatchedTo);
     tree_sig->SetBranchAddress("jet0_Eta", &jet0_Eta);
     tree_sig->SetBranchAddress("jet0_Pt", &jet0_Pt);
-    SignalSelection = Form("((LLP0_DecayR >= %f && LLP0_DecayR < %f && abs(LLP0_Eta) <= %f && jet0_isMatchedTo == 0) || (LLP1_DecayR >= %f && LLP1_DecayR < %f && abs(LLP1_Eta) <= %f && jet0_isMatchedTo == 1)) && (abs(jet0_Eta) < 1.26 && jet0_Pt > 40)", radius_HB1, radius_HBend, HBeta, radius_HB1, radius_HBend, HBeta);
-    HLT_Selection = "(HLT_HT200_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT240_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT280_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT270_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet60_DisplacedTrack == 1 || HLT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive == 1 || HLT_HT420_L1SingleLLPJet_DisplacedDijet60_Inclusive == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay1nsInclusive == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay2nsInclusive == 1)";
+    SafetySelection = "(abs(jet0_Eta) < 1.26 && jet0_Pt > 40)"; // to account for any per event entries with no valid jets
+    SignalSelection = Form("((LLP0_DecayR >= %f && LLP0_DecayR < %f && abs(LLP0_Eta) <= %f && jet0_isMatchedTo == 0) || (LLP1_DecayR >= %f && LLP1_DecayR < %f && abs(LLP1_Eta) <= %f && jet0_isMatchedTo == 1))", radius_HB1, radius_HBend, HBeta, radius_HB1, radius_HBend, HBeta);
     cout << "per event tree, adding signal region cuts on LLP position and matching" << endl;
     // hopefully there is a better way to implement these cuts, had TCut errors when imported RegionCuts.h on first try
     // reduces by a factor of about 10 for mh=125
@@ -539,7 +542,6 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
     tree_sig->SetBranchAddress("perJet_MatchedLLP_DecayR", &perJet_MatchedLLP_DecayR);
     tree_sig->SetBranchAddress("perJet_MatchedLLP_Eta", &perJet_MatchedLLP_Eta);
     SignalSelection = Form("perJet_MatchedLLP_DecayR >= %f && perJet_MatchedLLP_DecayR < %f && abs(perJet_MatchedLLP_Eta) < %f", radius_HB1, radius_HBend, 1.26);
-    HLT_Selection = "(HLT_HT200_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT240_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT280_L1SingleLLPJet_DisplacedDijet40_Inclusive1PtrkShortSig5 == 1 || HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT270_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack == 1 || HLT_HT200_L1SingleLLPJet_DisplacedDijet60_DisplacedTrack == 1 || HLT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive == 1 || HLT_HT420_L1SingleLLPJet_DisplacedDijet60_Inclusive == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay1nsInclusive == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless == 1 || HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay2nsInclusive == 1)";
     if (plotType.find("HCAL12") != std::string::npos) {
       SignalSelection = Form("perJet_MatchedLLP_DecayR >= %f && perJet_MatchedLLP_DecayR < %f && abs(perJet_MatchedLLP_Eta) < %f", radius_HB1, radius_HB3, 1.26);
       cout << "selection = HCAL depth 12 only" << endl;
@@ -552,23 +554,29 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
   }
 
   TFile *myReducedFile = new TFile("/afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/TMVAStudies/temp.root", "RECREATE"); // preventing error "This error is symptomatic of a Tree created as a memory-resident Tree"
-  TTree *tree_sig_reduced = tree_sig->CopyTree(SignalSelection, "", tree_sig->GetEntries(), 0); // no cuts needed for already jet matched tree
-  TTree *tree_sig_reduced_HLT = tree_sig_reduced->CopyTree(HLT_Selection, "", tree_sig_reduced->GetEntries(), 0); // no cuts needed for already jet matched tree
+  TTree *tree_sig_reduced = tree_sig->CopyTree(SafetySelection, "", tree_sig->GetEntries(), 0);
+  TTree *tree_sig_reduced_signal = tree_sig_reduced->CopyTree(SignalSelection, "", tree_sig_reduced->GetEntries(), 0); // no cuts needed for already jet matched tree
+  TTree *tree_sig_reduced_antiHLT = tree_sig_reduced_signal->CopyTree(Anti_HLT_Selection, "", tree_sig_reduced_signal->GetEntries(), 0); 
+  TTree *tree_sig_reduced_HLT = tree_sig_reduced_signal->CopyTree(HLT_Selection, "", tree_sig_reduced_signal->GetEntries(), 0); 
+  cout << "signal tree reduced, have safety selections, signal selections, and HLT selections applied " << endl;
 
   if (SigTree.find("PerJet") == std::string::npos) {
-    tree_sig_reduced->SetBranchAddress("jet0_bdtscoreX_LLP350_MS80_perJet", &score350_80_sig);
+    tree_sig_reduced_antiHLT->SetBranchAddress("jet0_bdtscoreX_LLP350_MS80_perJet", &score350_80_sig);
     tree_sig_reduced_HLT->SetBranchAddress("jet0_bdtscoreX_LLP350_MS80_perJet", &score350_80_sig_HLT);
   }
   if (SigTree.find("PerJet") != std::string::npos) {
-    tree_sig_reduced->SetBranchAddress(("bdtscore_LLP350_MS80"+plotType+"_perJet").c_str(), &score350_80_sig);
+    tree_sig_reduced_antiHLT->SetBranchAddress(("bdtscore_LLP350_MS80"+plotType+"_perJet").c_str(), &score350_80_sig);
+    tree_sig_reduced_HLT->SetBranchAddress(("bdtscore_LLP350_MS80"+plotType+"_perJet").c_str(), &score350_80_sig);
   }
 
   cout << "Total Entries (signal): " << tree_sig_reduced->GetEntries() << "\n";
-  cout << "Total Entries (signal): " << tree_sig_reduced_HLT->GetEntries() << "\n";
-  int nentries = tree_sig_reduced->GetEntries();
+  cout << "Total Entries (signal, no HLT): " << tree_sig_reduced_antiHLT->GetEntries() << "\n";
+  cout << "Total Entries (signal, with HLT): " << tree_sig_reduced_HLT->GetEntries() << "\n";
+  int nentries_all = tree_sig_reduced->GetEntries();
+  int nentries = tree_sig_reduced_antiHLT->GetEntries();
   int nentries_HLT = tree_sig_reduced_HLT->GetEntries();
   for(int ientry=0; ientry < nentries; ientry++) {       	
-    tree_sig_reduced->GetEntry(ientry);
+    tree_sig_reduced_antiHLT->GetEntry(ientry);
     Signal_MVA350_80->Fill(score350_80_sig);
   }
   for(int ientry=0; ientry < nentries_HLT; ientry++) {       	
@@ -597,10 +605,13 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
       //                                              "LLP125_MS15_HCAL34_calor_perJet", "LLP350_MS80_HCAL34_calor_perJet", "LLP125_MS50_HCAL34_calor_perJet", "LLP250_MS120_HCAL34_calor_perJet", "LLP350_MS160_HCAL34_calor_perJet", "hadd_HCAL34_calor_perJet"};
   }
 
-  cout << "Total Entries (background): " << tree_bkg->GetEntries() << "\n";
-  int nentries_bkg = tree_bkg->GetEntries();
+  TFile *myReducedFile2 = new TFile("/afs/cern.ch/work/g/gkopp/2022_LLP_analysis/Run3-HCAL-LLP-Analysis/TMVAStudies/temp.root", "RECREATE"); // preventing error "This error is symptomatic of a Tree created as a memory-resident Tree"
+  TTree *tree_bkg_reduced = tree_bkg->CopyTree(SafetySelection, "", tree_bkg->GetEntries(), 0);
+  cout << "background tree reduced, have safety selections, signal selections, and HLT selections applied " << endl;
+  cout << "Total Entries (background): " << tree_bkg_reduced->GetEntries() << "\n";
+  int nentries_bkg = tree_bkg_reduced->GetEntries();
   for(int ientry=0; ientry < nentries_bkg; ientry++) {       	
-    tree_bkg->GetEntry(ientry);
+    tree_bkg_reduced->GetEntry(ientry);
     
     if (ientry % 100000 == 0) cout << "Event " << ientry << endl;
 
@@ -681,8 +692,8 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
 
   ROCGraphs.push_back(ROC350_80_sigEffBkgEff);
   ROCGraphs.push_back(ROC350_80_sigEffBkgEff_HLT);
-  GraphLabels.push_back("MVA trained on 350 (mX80) for LLP vs. W+jets");
-  GraphLabels.push_back("MVA trained on 350 (mX80) for LLP (HLT required) vs. W+jets");
+  GraphLabels.push_back("MVA trained on 350 (LLP mS=80), HLT not passed");
+  GraphLabels.push_back("MVA trained on 350 (LLP mS=80), HLT passed");
   gStyle->SetPalette(kViridis);
   //colors.push_back(TColor::GetPalette().At(0));
   colors.push_back(TColor::GetPalette().At(50));
@@ -696,6 +707,7 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
   Double_t xmin = 0.0;
   Double_t xmax = 1.0;
   Double_t ymin = 0.3;
+  if (InputFile.find("MH-125_MS-15") != std::string::npos) ymin = 0;
   Double_t ymax = 1.0;
 
   bool overlay = true;
@@ -738,39 +750,41 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
     }
   }
 
-  if (InputFile.find("MH-125_MS-15") != std::string::npos) {
-    TGraphAsymmErrors* WP_jet_cutflow = MakeCurrentWPSigEffVsBkgEffGraph(0.66 , 0.0008, "WP_jet_cutflow"+label); // mh 125 working point, for per jet approach
-    legend->AddEntry(WP_jet_cutflow, "Cutflow Jet WP comparison (mH = 125)", "P");
-    WP_jet_cutflow->SetFillColor(kBlue);
-    WP_jet_cutflow->SetMarkerColor(kBlue);
-    WP_jet_cutflow->SetMarkerStyle(34);
-    WP_jet_cutflow->SetMarkerSize(1.5);
-    WP_jet_cutflow->Draw("Psame");  
+  if (SigTree.find("PerJet") != std::string::npos) { // if per event, cutflow does not make sense, as cutflow was done on a per jet basis! 
+    if (InputFile.find("MH-125_MS-15") != std::string::npos) {
+      TGraphAsymmErrors* WP_jet_cutflow = MakeCurrentWPSigEffVsBkgEffGraph(0.66 , 0.0008, "WP_jet_cutflow"+label); // mh 125 working point, for per jet approach
+      legend->AddEntry(WP_jet_cutflow, "Cutflow comparison (mH = 125)", "P");
+      WP_jet_cutflow->SetFillColor(kBlue);
+      WP_jet_cutflow->SetMarkerColor(kBlue);
+      WP_jet_cutflow->SetMarkerStyle(34);
+      WP_jet_cutflow->SetMarkerSize(1.5);
+      WP_jet_cutflow->Draw("Psame");  
 
-    // TGraphAsymmErrors* WP_BDTcut = MakeCurrentWPSigEffVsBkgEffAtCutValueGraph(Signal_MVA125_15, Background_MVA125_15, "Eff at fixed cut", 0.99);
-    // legend->AddEntry(WP_BDTcut, "BDT cut = 0.99 point (mH = 125)", "P");
-    // WP_BDTcut->SetFillColor(colors[0]);
-    // WP_BDTcut->SetMarkerColor(colors[0]);
-    // WP_BDTcut->SetMarkerStyle(34);
-    // WP_BDTcut->SetMarkerSize(1.5);
-    // WP_BDTcut->Draw("Psame"); 
-  }
-  if (InputFile.find("MH-350_MS-80") != std::string::npos) {
-    TGraphAsymmErrors* WP_jet_cutflow = MakeCurrentWPSigEffVsBkgEffGraph(0.77 , 0.0008, "WP_jet_cutflow"+label); // mh 350 working point, for per jet approach
-    legend->AddEntry(WP_jet_cutflow, "Cutflow Jet WP comparison (mH = 350)", "P");
-    WP_jet_cutflow->SetFillColor(kBlue);
-    WP_jet_cutflow->SetMarkerColor(kBlue);
-    WP_jet_cutflow->SetMarkerStyle(34);
-    WP_jet_cutflow->SetMarkerSize(1.5);
-    WP_jet_cutflow->Draw("Psame");  
+      // TGraphAsymmErrors* WP_BDTcut = MakeCurrentWPSigEffVsBkgEffAtCutValueGraph(Signal_MVA125_15, Background_MVA125_15, "Eff at fixed cut", 0.99);
+      // legend->AddEntry(WP_BDTcut, "BDT cut = 0.99 point (mH = 125)", "P");
+      // WP_BDTcut->SetFillColor(colors[0]);
+      // WP_BDTcut->SetMarkerColor(colors[0]);
+      // WP_BDTcut->SetMarkerStyle(34);
+      // WP_BDTcut->SetMarkerSize(1.5);
+      // WP_BDTcut->Draw("Psame"); 
+    }
+    if (InputFile.find("MH-350_MS-80") != std::string::npos) {
+      TGraphAsymmErrors* WP_jet_cutflow = MakeCurrentWPSigEffVsBkgEffGraph(0.77 , 0.0008, "WP_jet_cutflow"+label); // mh 350 working point, for per jet approach
+      legend->AddEntry(WP_jet_cutflow, "Cutflow comparison (mH = 350)", "P");
+      WP_jet_cutflow->SetFillColor(kBlue);
+      WP_jet_cutflow->SetMarkerColor(kBlue);
+      WP_jet_cutflow->SetMarkerStyle(34);
+      WP_jet_cutflow->SetMarkerSize(1.5);
+      WP_jet_cutflow->Draw("Psame");  
 
-    // TGraphAsymmErrors* WP_BDTcut = MakeCurrentWPSigEffVsBkgEffAtCutValueGraph(Signal_MVA350_80, Background_MVA350_80, "Eff at fixed cut", 0.99);
-    // legend->AddEntry(WP_BDTcut, "BDT cut = 0.99 point (mH = 350)", "P");
-    // WP_BDTcut->SetFillColor(colors[1]);
-    // WP_BDTcut->SetMarkerColor(colors[1]);
-    // WP_BDTcut->SetMarkerStyle(34);
-    // WP_BDTcut->SetMarkerSize(1.5);
-    // WP_BDTcut->Draw("Psame"); 
+      // TGraphAsymmErrors* WP_BDTcut = MakeCurrentWPSigEffVsBkgEffAtCutValueGraph(Signal_MVA350_80, Background_MVA350_80, "Eff at fixed cut", 0.99);
+      // legend->AddEntry(WP_BDTcut, "BDT cut = 0.99 point (mH = 350)", "P");
+      // WP_BDTcut->SetFillColor(colors[1]);
+      // WP_BDTcut->SetMarkerColor(colors[1]);
+      // WP_BDTcut->SetMarkerStyle(34);
+      // WP_BDTcut->SetMarkerSize(1.5);
+      // WP_BDTcut->Draw("Psame"); 
+    }
   }
 
   // overlay multiple ROC curves -- useful if comparing 125 vs. 350 for instance
@@ -816,18 +830,21 @@ void MakeMVAPerformancePlots_HLTcomp()
   SetupPlots();
 
   // Signals
-  string SignalTree = "PerJet_LLPmatched";
+  // string SignalTree = "PerJet_LLPmatched";
 
-  string Signal = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST.root";
-  string SigLabel = "125_mX15";
+  // string Signal = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST.root";
+  // string SigLabel = "125_mX15";
 
-  string Signal2 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST.root";
-  string SigLabel2 = "350_mX80";
+  // string Signal2 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST.root";
+  // string SigLabel2 = "350_mX80";
 
   // for per event analysis
-  // string Signal2 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST.root";
-  // string SigLabel2 = "350_mX80";
-  // string SignalTree = "NoSel";
+  string Signal = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-15_CTau1000_13p6TeV_2024_03_14_TEST.root";
+  string SigLabel = "125_mX15";
+
+  string Signal2 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-350_MS-80_CTau500_13p6TeV_2024_03_14_TEST.root";
+  string SigLabel2 = "350_mX80";
+  string SignalTree = "NoSel";
 
   string Signal3 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLP_MC_ggH_HToSSTobbbb_MH-125_MS-50_CTau3000_13p6TeV_2024_03_14_batch2.root";
   string SigLabel3 = "125_mX50";
@@ -839,13 +856,13 @@ void MakeMVAPerformancePlots_HLTcomp()
   string SigLabel5 = "350_mX160";
 
   // Backgrounds
-  // string Background = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/minituple_v3.7_LLPskim_Run2023_HADD.root";
-  // string BkgLabel = "W+Jets";
-  // string BackgroundTree = "WPlusJets";
+  string Background = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/minituple_v3.7_LLPskim_Run2023_HADD.root";
+  string BkgLabel = "W+Jets";
+  string BackgroundTree = "WPlusJets";
   // string Background = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLPskim_Run2023Cv4_2024_03_14.root";
-  string Background = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLPskim_Run2023_HADD.root";
-  string BkgLabel = "W+Jets_perJet";
-  string BackgroundTree = "PerJet_WPlusJets";
+  // string Background = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/minituple_v3.7_LLPskim_Run2023_HADD.root";
+  // string BkgLabel = "W+Jets_perJet";
+  // string BackgroundTree = "PerJet_WPlusJets";
 
   // minituple_v3.7_LLPskim_Run2023Bv1_2024_03_14.root
   // minituple_v3.7_LLPskim_Run2023Cv1_2024_03_14.root
@@ -862,8 +879,8 @@ void MakeMVAPerformancePlots_HLTcomp()
   vector<string> plotType = {""}; // {"_calor", "_HCAL12_calor", "_HCAL34_calor", "", "_HCAL12", "_HCAL34"};
   for( auto type: plotType){
     if (type != "") fs::create_directory(type);
-    // BDTPerformancePlots(Signal, SigLabel, SignalTree, Background, BkgLabel, BackgroundTree, Color1, Color2, Color3, type);
-    // SetupPlots();
+    BDTPerformancePlots(Signal, SigLabel, SignalTree, Background, BkgLabel, BackgroundTree, Color1, Color2, Color3, type);
+    SetupPlots();
     BDTPerformancePlots(Signal2, SigLabel2, SignalTree, Background, BkgLabel, BackgroundTree, Color1, Color2, Color3, type);
     SetupPlots();
     // BDTPerformancePlots(Signal3, SigLabel3, SignalTree, Background, BkgLabel, BackgroundTree, Color1, Color2, Color3, type);

--- a/TMVAStudies/MakeMVAPerformancePlots_SigBkg.C
+++ b/TMVAStudies/MakeMVAPerformancePlots_SigBkg.C
@@ -470,7 +470,7 @@ void SetupPlots()
   GraphLabels.clear();
   PlotnameSpecific.clear();
 
-  legend = new TLegend(0.32,0.12,0.9,0.34);
+  legend = new TLegend(0.42,0.12,0.9,0.34);
   legend->SetTextSize(0.03);
   legend->SetBorderSize(0);
   legend->SetFillStyle(0);
@@ -491,19 +491,19 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
   //--------------------------------------------------------------------------------------------------------------
   // Histograms
   //==============================================================================================================  
-  TH1F *Signal_MVA125_15 = new TH1F(("Signal_MVA125_15"+label).c_str(), "LLP Signal ; MVA (BDT trained on 125, mX15) score for LLP signal ; Number of Events ",  5500, -1.1 , 1.1);
-  TH1F *Signal_MVA350_80 = new TH1F(("Signal_MVA350_80"+label).c_str(), "LLP Signal ; MVA (BDT trained on 350, mX80) score for LLP signal ; Number of Events ",  5500, -1.1 , 1.1);
-  TH1F *Signal_MVA125_50 = new TH1F(("Signal_MVA125_50"+label).c_str(), "LLP Signal ; MVA (BDT trained on 125, mX50) score for LLP signal ; Number of Events ",  5500, -1.1 , 1.1);
-  TH1F *Signal_MVA250_120 = new TH1F(("Signal_MVA250_120"+label).c_str(), "LLP Signal ; MVA (BDT trained on 250, mX120) score for LLP signal ; Number of Events ",  5500, -1.1 , 1.1);
-  TH1F *Signal_MVA350_160 = new TH1F(("Signal_MVA350_160"+label).c_str(), "LLP Signal ; MVA (BDT trained on 350, mX160) score for LLP signal ; Number of Events ",  5500, -1.1 , 1.1);
-  TH1F *Signal_MVAhadd = new TH1F(("Signal_MVAhadd"+label).c_str(), "LLP Signal ; MVA (BDT trained on combination) score for LLP signal ; Number of Events ",  5500, -1.1 , 1.1);
+  TH1F *Signal_MVA125_15 = new TH1F(("Signal_MVA125_15"+label).c_str(), "LLP Signal ; MVA (BDT trained on 125, mX15) score for LLP signal ; Number of Events ",  55000, -1.1 , 1.1);
+  TH1F *Signal_MVA350_80 = new TH1F(("Signal_MVA350_80"+label).c_str(), "LLP Signal ; MVA (BDT trained on 350, mX80) score for LLP signal ; Number of Events ",  55000, -1.1 , 1.1);
+  TH1F *Signal_MVA125_50 = new TH1F(("Signal_MVA125_50"+label).c_str(), "LLP Signal ; MVA (BDT trained on 125, mX50) score for LLP signal ; Number of Events ",  55000, -1.1 , 1.1);
+  TH1F *Signal_MVA250_120 = new TH1F(("Signal_MVA250_120"+label).c_str(), "LLP Signal ; MVA (BDT trained on 250, mX120) score for LLP signal ; Number of Events ",  55000, -1.1 , 1.1);
+  TH1F *Signal_MVA350_160 = new TH1F(("Signal_MVA350_160"+label).c_str(), "LLP Signal ; MVA (BDT trained on 350, mX160) score for LLP signal ; Number of Events ",  55000, -1.1 , 1.1);
+  TH1F *Signal_MVAhadd = new TH1F(("Signal_MVAhadd"+label).c_str(), "LLP Signal ; MVA (BDT trained on combination) score for LLP signal ; Number of Events ",  55000, -1.1 , 1.1);
 
-  TH1F *Background_MVA125_15 = new TH1F(("Background_MVA125_15"+label).c_str(), "W+Jets Background ; MVA (BDT trained on 125, mX15) score for W+jets background ; Number of Events ",  5500, -1.1 , 1.1);
-  TH1F *Background_MVA350_80 = new TH1F(("Background_MVA350_80"+label).c_str(), "W+Jets Background ; MVA (BDT trained on 350, mX80) score for W+jets background ; Number of Events ",  5500, -1.1 , 1.1);
-  TH1F *Background_MVA125_50 = new TH1F(("Background_MVA125_50"+label).c_str(), "W+jets Background ; MVA (BDT trained on 125, mX50) score for W+jets Background ; Number of Events ",  5500, -1.1 , 1.1);
-  TH1F *Background_MVA250_120 = new TH1F(("Background_MVA250_120"+label).c_str(), "W+jets Background ; MVA (BDT trained on 250, mX120) score for W+jets Background ; Number of Events ",  5500, -1.1 , 1.1);
-  TH1F *Background_MVA350_160 = new TH1F(("Background_MVA350_160"+label).c_str(), "W+jets Background ; MVA (BDT trained on 350, mX160) score for W+jets Background ; Number of Events ",  5500, -1.1 , 1.1);
-  TH1F *Background_MVAhadd = new TH1F(("Background_MVAhadd"+label).c_str(), "W+Jets Background ; MVA (BDT trained on combination) score for W+jets background ; Number of Events ",  5500, -1.1 , 1.1);
+  TH1F *Background_MVA125_15 = new TH1F(("Background_MVA125_15"+label).c_str(), "W+Jets Background ; MVA (BDT trained on 125, mX15) score for W+jets background ; Number of Events ",  55000, -1.1 , 1.1);
+  TH1F *Background_MVA350_80 = new TH1F(("Background_MVA350_80"+label).c_str(), "W+Jets Background ; MVA (BDT trained on 350, mX80) score for W+jets background ; Number of Events ",  55000, -1.1 , 1.1);
+  TH1F *Background_MVA125_50 = new TH1F(("Background_MVA125_50"+label).c_str(), "W+jets Background ; MVA (BDT trained on 125, mX50) score for W+jets Background ; Number of Events ",  55000, -1.1 , 1.1);
+  TH1F *Background_MVA250_120 = new TH1F(("Background_MVA250_120"+label).c_str(), "W+jets Background ; MVA (BDT trained on 250, mX120) score for W+jets Background ; Number of Events ",  55000, -1.1 , 1.1);
+  TH1F *Background_MVA350_160 = new TH1F(("Background_MVA350_160"+label).c_str(), "W+jets Background ; MVA (BDT trained on 350, mX160) score for W+jets Background ; Number of Events ",  55000, -1.1 , 1.1);
+  TH1F *Background_MVAhadd = new TH1F(("Background_MVAhadd"+label).c_str(), "W+Jets Background ; MVA (BDT trained on combination) score for W+jets background ; Number of Events ",  55000, -1.1 , 1.1);
 
   Double_t RealElectrons = 0;
   Double_t FakeElectrons = 0;
@@ -699,42 +699,6 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
   plotname = Label;
 
   //*****************************************************************************************
-  // Overlay signal and background BDT scores
-  //*****************************************************************************************
-  THStack *hs = new THStack("hs", Form("Signal and Background BDT Scores (mH=%s) ; BDT (trained on 125) Score ; Number of Entries",Label.c_str()));
-  Signal_MVA125_15->SetFillColorAlpha(kBlue, 0.35);
-  Background_MVA125_15->SetFillColorAlpha(kRed, 0.35);
-  Signal_MVA125_15->Rebin(50);
-  Background_MVA125_15->Rebin(50);
-  hs->Add(Signal_MVA125_15);
-  hs->Add(Background_MVA125_15);
-  cv_indiv->cd();
-  hs->Draw("bar1 nostack");
-  gPad->BuildLegend(0.65,0.65,0.85,0.85,"");
-  StampCMS( "Internal", 140., 0.2, 0.84, 0.045 );
-  cv_indiv->SaveAs((plotDir + "Minituple_BDT125score_" + plotname + ".png").c_str());
-  gPad->SetLogy();
-  cv_indiv->SaveAs((plotDir + "Minituple_BDT125score_" + plotname + "_logY.png").c_str());
-  cv_indiv->Clear();
-
-  THStack *hs2 = new THStack("hs2", Form("Signal and Background BDT Scores (mH=%s) ; BDT (trained on 350) Score ; Number of Entries",Label.c_str()));
-  Signal_MVA350_80->SetFillColorAlpha(kBlue, 0.35);
-  Background_MVA350_80->SetFillColorAlpha(kRed, 0.35);
-  Signal_MVA350_80->Rebin(50);
-  Background_MVA350_80->Rebin(50);
-  hs2->Add(Signal_MVA350_80);
-  hs2->Add(Background_MVA350_80);
-  cv_indiv->cd();
-  hs2->Draw("bar1 nostack");
-  gPad->BuildLegend(0.65,0.65,0.85,0.85,"");
-  StampCMS( "Internal", 140., 0.2, 0.84, 0.045 );
-  gPad->SetLogy(0);
-  cv_indiv->SaveAs((plotDir + "Minituple_BDT350score_" + plotname + ".png").c_str());
-  gPad->SetLogy();
-  cv_indiv->SaveAs((plotDir + "Minituple_BDT350score_" + plotname + "_logY.png").c_str());
-  cv_indiv->Clear();
-
-  //*****************************************************************************************
   //Plot ROC Curves
   //*****************************************************************************************
 
@@ -744,12 +708,12 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
   ROCGraphs.push_back(ROC250_120_sigEffBkgEff);
   ROCGraphs.push_back(ROC350_160_sigEffBkgEff);
   ROCGraphs.push_back(ROChadd_sigEffBkgEff);
-  GraphLabels.push_back("MVA trained on 125 (mX15) for LLP vs. W+jets");
-  GraphLabels.push_back("MVA trained on 350 (mX80) for LLP vs. W+jets");
-  GraphLabels.push_back("MVA trained on 125 (mX50) for LLP vs. W+jets");
-  GraphLabels.push_back("MVA trained on 250 (mX120) for LLP vs. W+jets");
-  GraphLabels.push_back("MVA trained on 350 (mX160) for LLP vs. W+jets");
-  GraphLabels.push_back("MVA trained on combination for LLP vs. W+jets");
+  GraphLabels.push_back("MVA trained on 125 (LLP mS=15)"); //  for LLP vs. W+jets");
+  GraphLabels.push_back("MVA trained on 350 (LLP mS=80)");
+  GraphLabels.push_back("MVA trained on 125 (LLP mS=50)");
+  GraphLabels.push_back("MVA trained on 250 (LLP mS=120)");
+  GraphLabels.push_back("MVA trained on 350 (LLP mS=160)");
+  GraphLabels.push_back("MVA trained on LLP combination");
   // colors.push_back(Option);
   // colors.push_back(Option2);
   // colors.push_back(Option3);
@@ -835,7 +799,7 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
     mass = "350";
   }
   TGraphAsymmErrors* WP_jet_cutflow = MakeCurrentWPSigEffVsBkgEffGraph(signal_eff , 0.0008, "WP_jet_cutflow"+label); 
-  legend->AddEntry(WP_jet_cutflow, Form("Cutflow Jet WP comparison (mH = %s)", mass.c_str()), "P");
+  legend->AddEntry(WP_jet_cutflow, Form("Cutflow comparison (mH = %s)", mass.c_str()), "P");
   WP_jet_cutflow->SetFillColor(kBlue);
   WP_jet_cutflow->SetMarkerColor(kBlue);
   WP_jet_cutflow->SetMarkerStyle(34);
@@ -852,8 +816,8 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
     // WP_BDTcut->Draw("Psame"); 
   // }
   // if (InputFile.find("MH-350_MS-80") != std::string::npos) {
-    TGraphAsymmErrors* WP_BDTcut = MakeCurrentWPSigEffVsBkgEffAtCutValueGraph(Signal_MVA350_80, Background_MVA350_80, "Eff at fixed cut", 0.998);
-    legend->AddEntry(WP_BDTcut, Form("BDT cut = 0.998 (mH = %s)", mass.c_str()), "P");
+    TGraphAsymmErrors* WP_BDTcut = MakeCurrentWPSigEffVsBkgEffAtCutValueGraph(Signal_MVA350_80, Background_MVA350_80, "Eff at fixed cut", 0.9999);
+    legend->AddEntry(WP_BDTcut, Form("BDT cut = 0.9999 (mH = %s)", mass.c_str()), "P");
     WP_BDTcut->SetFillColor(kBlack);
     WP_BDTcut->SetMarkerColor(kBlack);
     WP_BDTcut->SetMarkerStyle(34);
@@ -894,6 +858,42 @@ void BDTPerformancePlots(string InputFile, string Label, string SigTree, string 
   legend->Draw();
   StampCMS( "Internal", 140., 0.14, 0.84, 0.045 );
   // cv_indiv->SaveAs((plotDir + "SigEffVsCutValue"+label+".png").c_str());
+
+  //*****************************************************************************************
+  // Overlay signal and background BDT scores
+  //*****************************************************************************************
+  THStack *hs = new THStack("hs", Form("Signal and Background BDT Scores (mH=%s) ; BDT (trained on 125) Score ; Number of Entries",Label.c_str()));
+  Signal_MVA125_15->SetFillColorAlpha(kBlue, 0.35);
+  Background_MVA125_15->SetFillColorAlpha(kRed, 0.35);
+  Signal_MVA125_15->Rebin(50);
+  Background_MVA125_15->Rebin(50);
+  hs->Add(Signal_MVA125_15);
+  hs->Add(Background_MVA125_15);
+  cv_indiv->cd();
+  hs->Draw("bar1 nostack");
+  gPad->BuildLegend(0.65,0.65,0.85,0.85,"");
+  StampCMS( "Internal", 140., 0.2, 0.84, 0.045 );
+  cv_indiv->SaveAs((plotDir + "Minituple_BDT125score_" + plotname + ".png").c_str());
+  gPad->SetLogy();
+  cv_indiv->SaveAs((plotDir + "Minituple_BDT125score_" + plotname + "_logY.png").c_str());
+  cv_indiv->Clear();
+
+  THStack *hs2 = new THStack("hs2", Form("Signal and Background BDT Scores (mH=%s) ; BDT (trained on 350) Score ; Number of Entries",Label.c_str()));
+  Signal_MVA350_80->SetFillColorAlpha(kBlue, 0.35);
+  Background_MVA350_80->SetFillColorAlpha(kRed, 0.35);
+  Signal_MVA350_80->Rebin(50);
+  Background_MVA350_80->Rebin(50);
+  hs2->Add(Signal_MVA350_80);
+  hs2->Add(Background_MVA350_80);
+  cv_indiv->cd();
+  hs2->Draw("bar1 nostack");
+  gPad->BuildLegend(0.65,0.65,0.85,0.85,"");
+  StampCMS( "Internal", 140., 0.2, 0.84, 0.045 );
+  gPad->SetLogy(0);
+  cv_indiv->SaveAs((plotDir + "Minituple_BDT350score_" + plotname + ".png").c_str());
+  gPad->SetLogy();
+  cv_indiv->SaveAs((plotDir + "Minituple_BDT350score_" + plotname + "_logY.png").c_str());
+  cv_indiv->Clear();
 }
 
 

--- a/VersionTracking.md
+++ b/VersionTracking.md
@@ -218,11 +218,13 @@ Updates:
 Location of minituples:
 ```
 /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/
+/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7.1/
 ```
 
 ### v3.8
 Updates:
 * Fixed bug where HLT results are not saved in per-jet trees (useful for HLT comparison ROC curves)
+* Fixed bug in calculation of LLP DecayT
 
 ## V4
 Ongoing wish list:

--- a/VersionTracking.md
+++ b/VersionTracking.md
@@ -220,6 +220,10 @@ Location of minituples:
 /eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.7/
 ```
 
+### v3.8
+Updates:
+* Fixed bug where HLT results are not saved in per-jet trees (useful for HLT comparison ROC curves)
+
 ## V4
 Ongoing wish list:
 * MET filters

--- a/VersionTracking.md
+++ b/VersionTracking.md
@@ -223,8 +223,15 @@ Location of minituples:
 
 ### v3.8
 Updates:
-* Fixed bug where HLT results are not saved in per-jet trees (useful for HLT comparison ROC curves)
+* Fixed bug where HLT results are not saved in per-jet trees (useful for HLT comparison ROC curves, and for making trigger efficiency plots on a per jet basis)
 * Fixed bug in calculation of LLP DecayT
+* Saved NoSel trees for LLP skim to enable comparisons of full distributions on dataset and W+jets to understand background estimation limitations
+* BDT (v0.7) trained on v3.6 minituples
+
+Location of minituples:
+```
+/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v3.8/
+```
 
 ## V4
 Ongoing wish list:


### PR DESCRIPTION
Significant work on background estimation code, signal in 0,1,2 jet tag region, and expected LLP sensitivities (plot branching ratio vs ctau). Cutflow tables updated for thesis results. Trigger efficiency plots are also added, via a new method in MinituplePlotter.

v3.8 minituples, with below changes. 

* Fixed bug where HLT results are not saved in per-jet trees (useful for HLT comparison ROC curves, and for making trigger efficiency plots on a per jet basis)
* Fixed bug in calculation of LLP DecayT
* Saved NoSel trees for LLP skim to enable comparisons of full distributions on dataset and W+jets to understand background estimation limitations
* BDT (v0.7) trained on v3.6 minituples