### PR TITLE
Preselection update: WPlusJets veto and depth emulation requirement

### DIFF
--- a/DisplacedHcalJetAnalyzer/DisplacedHcalJetAnalyzer/DisplacedHcalJetAnalyzer.h
+++ b/DisplacedHcalJetAnalyzer/DisplacedHcalJetAnalyzer/DisplacedHcalJetAnalyzer.h
@@ -809,7 +809,7 @@ public :
    virtual void   ResetGlobalEventVars();
    virtual bool   PassL1SingleLLPJet();
    virtual bool   PassHLTDisplacedJet();
-   virtual bool   PassEventPreselection( bool passedHLT = false );
+   virtual bool   PassEventPreselection( bool PassedHLT = false, bool PassedWPlusJets = true );
    virtual bool   PassWPlusJetsSelection();
    virtual bool   PassLeptonVeto();
    virtual bool   PassZmumuSelection();

--- a/DisplacedHcalJetAnalyzer/src/EventHelper.cxx
+++ b/DisplacedHcalJetAnalyzer/src/EventHelper.cxx
@@ -74,7 +74,7 @@ bool DisplacedHcalJetAnalyzer::PassHLTDisplacedJet(){
 }
 
 /* ====================================================================================================================== */
-bool DisplacedHcalJetAnalyzer::PassEventPreselection( bool PassedHLT ){
+bool DisplacedHcalJetAnalyzer::PassEventPreselection( bool PassedHLT, bool PassedWPlusJets ){
 
 	if( debug ) cout<<"DisplacedHcalJetAnalyzer::PassEventPreselection()"<<endl;
 
@@ -86,6 +86,12 @@ bool DisplacedHcalJetAnalyzer::PassEventPreselection( bool PassedHLT ){
 
 	if( !PassedHLT ){  // check again if already false
 		if( !PassHLTDisplacedJet() ) return false;
+	}
+
+	// Veto on W Plus Jets //
+
+	if( PassedWPlusJets ){ // Default is true
+		if( PassWPlusJetsSelection() ) return false;
 	}
 
 	// Depth Tag Jet //
@@ -110,6 +116,9 @@ bool DisplacedHcalJetAnalyzer::PassEventPreselection( bool PassedHLT ){
 
 		// Reject if fails HW qual 
 		if( dR > 0.4 || L1trig < 1 ) continue;
+
+		// Require 2+ depth towers
+		if( GetDepthTowers_Jet(i, 0.4) < 2 ) continue;
 		
 		depthtag_jet_candidate = i;
 

--- a/DisplacedHcalJetAnalyzer/src/Loop.cxx
+++ b/DisplacedHcalJetAnalyzer/src/Loop.cxx
@@ -23,10 +23,11 @@ void DisplacedHcalJetAnalyzer::ProcessEvent(Long64_t jentry){
 	map<string, bool> Pass_EventSelections = {};
 	Pass_EventSelections["Pass_L1SingleLLPJet"]  = PassL1SingleLLPJet();
 	Pass_EventSelections["Pass_HLTDisplacedJet"] = PassHLTDisplacedJet();
-	Pass_EventSelections["Pass_PreSel"]          = PassEventPreselection( Pass_EventSelections["Pass_HLTDisplacedJet"] );
 	Pass_EventSelections["Pass_WPlusJets"]       = PassWPlusJetsSelection();
 	Pass_EventSelections["Pass_ZPlusJets"]       = PassZmumuSelection();	
 	Pass_EventSelections["Pass_NoLepton"]        = PassLeptonVeto();
+
+	Pass_EventSelections["Pass_PreSel"]          = PassEventPreselection( Pass_EventSelections["Pass_HLTDisplacedJet"], Pass_EventSelections["Pass_WPlusJets"] );
 
 	if( Pass_EventSelections["Pass_ZPlusJets"] ) Pass_EventSelections["Pass_WPlusJets"] = false;
 


### PR DESCRIPTION
updated event preselection to veto on W+Jets selection and require 2+depth towers for depth candidates