### PR TITLE
ANv6: HLT prescales, lumi frac, era category

### DIFF
--- a/Classifiers/Evaluate/ScoresToEventBased.py
+++ b/Classifiers/Evaluate/ScoresToEventBased.py
@@ -82,7 +82,7 @@ class DataProcessor:
         print("Processing...")
 
         features = ['perJet_Eta', 'perJet_Mass', 
-#        'perJet_S_phiphi', 'perJet_S_etaeta', 'perJet_S_etaphi', 
+       'perJet_S_phiphi', 'perJet_S_etaeta', 'perJet_S_etaphi', # for v5 DNN, remove for v6 DNN
        'perJet_Tracks_dR', 
        'perJet_Track0dR', 'perJet_Track0dEta', 'perJet_Track0dPhi', 
        'perJet_Track1dR', 'perJet_Track1dEta', 'perJet_Track1dPhi',

--- a/DisplacedHcalJetAnalyzer/DisplacedHcalJetAnalyzer/DisplacedHcalJetAnalyzer.h
+++ b/DisplacedHcalJetAnalyzer/DisplacedHcalJetAnalyzer/DisplacedHcalJetAnalyzer.h
@@ -70,6 +70,7 @@ public :
    float event_weight = 1;
    float weight_unskimmed = 1;
    double lumi_samplefrac = 1.0;
+   double lumi_frac = 1.0;
 
    Long64_t NEvents   = -1; 
    Long64_t NEvents_HLT = -1;
@@ -85,6 +86,7 @@ public :
    std::map<std::string, TH2F*> vetoMaps_; // this will load all maps, then look thme up by era
 
    std::string currentEra_ = "UNKNOWN";
+   int currentEraCategory_ = -1;
 
    // ----- My Hists ----- //
 

--- a/DisplacedHcalJetAnalyzer/src/EventHelper.cxx
+++ b/DisplacedHcalJetAnalyzer/src/EventHelper.cxx
@@ -39,7 +39,20 @@ void DisplacedHcalJetAnalyzer::SetEra(){
 
 	if ( debug ) cout<<"DisplacedHcalJetAnalyzer::SetEra()"<<endl;
 
-	currentEra_ = *era; 
+	currentEra_ = *era;
+
+	// 1 = preEE         : MC 2022preEE,   data 2022C, 2022D
+	// 2 = postEE+preBPix: MC 2022postEE, 2023preBPix, data 2022E, 2022F, 2022G, 2023C
+	// 3 = postBPix      : MC 2023postBPix, data 2023D
+	if      (currentEra_ == "2022preEE"   || currentEra_ == "Run2022C" || currentEra_ == "Run2022D")
+		currentEraCategory_ = 1;
+	else if (currentEra_ == "2022postEE"  || currentEra_ == "2023preBPix" ||
+	         currentEra_ == "Run2022E"       || currentEra_ == "Run2022F" || currentEra_ == "Run2022G" || currentEra_ == "Run2023C")
+		currentEraCategory_ = 2;
+	else if (currentEra_ == "2023postBPix" || currentEra_ == "Run2023D")
+		currentEraCategory_ = 3;
+	else
+		currentEraCategory_ = -1;
 
 }
 

--- a/DisplacedHcalJetAnalyzer/src/OutputHelper.cxx
+++ b/DisplacedHcalJetAnalyzer/src/OutputHelper.cxx
@@ -41,7 +41,7 @@ void DisplacedHcalJetAnalyzer::DeclareOutputTrees(){
 	// Add Event Variables //
 
 	vector<string> myvars_int = {
-		"run","lumi","event","PV","jet","validJet","muon","ele","pho",
+		"run","lumi","event","era_category","PV","jet","validJet","muon","ele","pho",
 		"RechitN","RechitN_1GeV","RechitN_5GeV","RechitN_10GeV",
 		"TrackN", "ecalRechitN", "HBHE_Rechit_auxTDC"
 	};
@@ -55,7 +55,7 @@ void DisplacedHcalJetAnalyzer::DeclareOutputTrees(){
 	}
 
 	vector<string> myvars_float = {
-		"met_Pt", "met_Phi", "met_SumEt", "eventHT", "weight", "event_weight", "randomFloat",
+		"met_Pt", "met_Phi", "met_SumEt", "eventHT", "weight", "event_weight", "lumi_frac", "randomFloat",
 		// Per-trigger L1 prescale values. Stored as float because the ntupler
 		// stores them as double. Value is -1 when L1 branches are absent.
 		// For MC, the ntupler fills luminosity-weighted effective prescales
@@ -383,7 +383,7 @@ void DisplacedHcalJetAnalyzer::DeclareOutputJetTrees(){
 
 	// Add Event Variables //
 	vector<string> myvars_int = {
-		"run","lumi","event","jetIndex",
+		"run","lumi","event","jetIndex","era_category",
 		"PV","jet","muon","ele","pho",
 	};
 
@@ -560,6 +560,7 @@ void DisplacedHcalJetAnalyzer::FillOutputTrees( string treename, map<string, boo
 
 	tree_output_vars_int["run"] 	= runNum;
 	tree_output_vars_string["era"] 	= currentEra_;
+	tree_output_vars_int["era_category"] = currentEraCategory_;
 	tree_output_vars_int["lumi"] 	= lumiNum;
 	tree_output_vars_int["event"] 	= eventNum;
 	tree_output_vars_int["PV"] 		= n_PV;
@@ -577,6 +578,7 @@ void DisplacedHcalJetAnalyzer::FillOutputTrees( string treename, map<string, boo
 
 	tree_output_vars_float["eventHT"]   = EventHT();
 	tree_output_vars_float["weight"]	= weight; // from SetWeight() in WeightsHelper.cxx
+	tree_output_vars_float["lumi_frac"]	= lumi_frac; // from SetWeight() in WeightsHelper.cxx
 	tree_output_vars_float["event_weight"]	= event_weight; 
 
 	for (int i = 0; i < HLT_Indices.size(); i++) {
@@ -624,31 +626,44 @@ void DisplacedHcalJetAnalyzer::FillOutputTrees( string treename, map<string, boo
 	}
 	tree_output_vars_float["L1_prescale_weight"] = l1_prescale_weight;
 
-	// HLT prescale weight: 0 if no HLT fires; 1 if any HLT fires, except when the only
-	// L1SingleLLPJet HLT that fired is the _35_ variant (disabled 34.95% of the time in data).
-	// In that MC-only special case, emulate the 65.05% acceptance with a deterministic draw.
-	float hlt_prescale_weight = 0.0f;
-	bool any_hlt = false;
-	for (int i = 0; i < (int)HLT_Names.size(); i++)
-		if (HLT_Names[i].find("L1SingleLLPJet") != string::npos &&
-		    i < (int)HLT_Decision->size() && HLT_Decision->at(i))
-			{ any_hlt = true; break; }
-	if (any_hlt) {
-		hlt_prescale_weight = 1.0f;
-		if (!isData) {
-			bool hlt35 = GetTriggerDecision("HLT_HT200_L1SingleLLPJet_DisplacedDijet35_Inclusive1PtrkShortSig5");
-			bool other_llpjet_hlt = false;
-			for (int i = 0; i < (int)HLT_Names.size(); i++) {
-				if (HLT_Names[i] == "HLT_HT200_L1SingleLLPJet_DisplacedDijet35_Inclusive1PtrkShortSig5") continue;
-				if (HLT_Names[i].find("L1SingleLLPJet") != string::npos &&
-				    i < (int)HLT_Decision->size() && HLT_Decision->at(i))
-					other_llpjet_hlt = true;
-			}
-			if (hlt35 && !other_llpjet_hlt) {
-				TRandom3 hlt_rng(lumiNum * 1000033u + (UInt_t)eventNum);
-				hlt_prescale_weight = (hlt_rng.Uniform() < 0.6505) ? 1.0f : 0.0f;
-			}
+	// HLT prescale weight — corrects for the _35_ dijet variant being prescaled in some eras.
+	// This is a prescale correction, not a trigger efficiency: 1 unless the prescale caused a loss.
+	//   preEE MC / data: no prescale correction needed → always 1
+	//   postEE + preBPix MC: _35_ prescaled for 27.67% of era → if only _35_ fired, accept with prob 0.7233
+	//   postBPix MC: _35_ fully disabled → if only _35_ fired, weight 0
+	float hlt_prescale_weight = 1.0f;
+	static bool hlt_prescale_debug_printed = false;
+	if (hlt_prescale_debug_printed) {
+		cout << "DEBUG HLT prescale: era=" << currentEra_ << " isData=" << isData << endl;
+		hlt_prescale_debug_printed = false;
+	}
+	if (!isData && (currentEra_ == "2022postEE" || currentEra_ == "2023preBPix")) {
+		bool hlt35 = GetTriggerDecision("HLT_HT200_L1SingleLLPJet_DisplacedDijet35_Inclusive1PtrkShortSig5");
+		bool other_llpjet_hlt = false;
+		for (int i = 0; i < (int)HLT_Names.size(); i++) {
+			if (HLT_Names[i] == "HLT_HT200_L1SingleLLPJet_DisplacedDijet35_Inclusive1PtrkShortSig5") continue;
+			if (HLT_Names[i].find("L1SingleLLPJet") != string::npos &&
+			    HLT_Names[i] != "HLT_L1SingleLLPJet" &&
+			    i < (int)HLT_Decision->size() && HLT_Decision->at(i))
+				other_llpjet_hlt = true;
 		}
+		if (hlt35 && !other_llpjet_hlt) {
+			TRandom3 hlt_rng(lumiNum * 1000033u + (UInt_t)eventNum);
+			hlt_prescale_weight = (hlt_rng.Uniform() < 0.7233) ? 1.0f : 0.0f;
+		}
+	}
+	if (!isData && currentEra_ == "2023postBPix") {
+		bool hlt35 = GetTriggerDecision("HLT_HT200_L1SingleLLPJet_DisplacedDijet35_Inclusive1PtrkShortSig5");
+		bool other_llpjet_hlt = false;
+		for (int i = 0; i < (int)HLT_Names.size(); i++) {
+			if (HLT_Names[i] == "HLT_HT200_L1SingleLLPJet_DisplacedDijet35_Inclusive1PtrkShortSig5") continue;
+			if (HLT_Names[i].find("L1SingleLLPJet") != string::npos &&
+			    HLT_Names[i] != "HLT_L1SingleLLPJet" &&
+			    i < (int)HLT_Decision->size() && HLT_Decision->at(i))
+				other_llpjet_hlt = true;
+		}
+		if (hlt35 && !other_llpjet_hlt)
+			hlt_prescale_weight = 0.0f;
 	}
 	tree_output_vars_float["HLT_prescale_weight"] = hlt_prescale_weight;
 
@@ -1009,6 +1024,7 @@ void DisplacedHcalJetAnalyzer::FillOutputJetTrees( string treename, int jetIndex
 	
 	jet_tree_output_vars_int["run"] 		= runNum;
 	jet_tree_output_vars_string["era"] 	    = currentEra_;
+	jet_tree_output_vars_int["era_category"] = currentEraCategory_;
 	jet_tree_output_vars_int["lumi"] 		= lumiNum;
 	jet_tree_output_vars_int["event"] 		= eventNum;
 	jet_tree_output_vars_int["jetIndex"] 	= jetIndex;
@@ -1057,28 +1073,34 @@ void DisplacedHcalJetAnalyzer::FillOutputJetTrees( string treename, int jetIndex
 	jet_tree_output_vars_float["L1_prescale_weight"] = l1_prescale_weight_jet;
 
 	// HLT prescale weight (same logic and seed as event tree — identical seed gives same outcome per event)
-	float hlt_prescale_weight_jet = 0.0f;
-	bool any_hlt_jet = false;
-	for (int i = 0; i < (int)HLT_Names.size(); i++)
-		if (HLT_Names[i].find("L1SingleLLPJet") != string::npos &&
-		    i < (int)HLT_Decision->size() && HLT_Decision->at(i))
-			{ any_hlt_jet = true; break; }
-	if (any_hlt_jet) {
-		hlt_prescale_weight_jet = 1.0f;
-		if (!isData) {
-			bool hlt35_jet = GetTriggerDecision("HLT_HT200_L1SingleLLPJet_DisplacedDijet35_Inclusive1PtrkShortSig5");
-			bool other_llpjet_hlt_jet = false;
-			for (int i = 0; i < (int)HLT_Names.size(); i++) {
-				if (HLT_Names[i] == "HLT_HT200_L1SingleLLPJet_DisplacedDijet35_Inclusive1PtrkShortSig5") continue;
-				if (HLT_Names[i].find("L1SingleLLPJet") != string::npos &&
-				    i < (int)HLT_Decision->size() && HLT_Decision->at(i))
-					other_llpjet_hlt_jet = true;
-			}
-			if (hlt35_jet && !other_llpjet_hlt_jet) {
-				TRandom3 hlt_rng_jet(lumiNum * 1000033u + (UInt_t)eventNum);
-				hlt_prescale_weight_jet = (hlt_rng_jet.Uniform() < 0.6505) ? 1.0f : 0.0f;
-			}
+	float hlt_prescale_weight_jet = 1.0f;
+	if (!isData && (currentEra_ == "2022postEE" || currentEra_ == "2023preBPix")) {
+		bool hlt35_jet = GetTriggerDecision("HLT_HT200_L1SingleLLPJet_DisplacedDijet35_Inclusive1PtrkShortSig5");
+		bool other_llpjet_hlt_jet = false;
+		for (int i = 0; i < (int)HLT_Names.size(); i++) {
+			if (HLT_Names[i] == "HLT_HT200_L1SingleLLPJet_DisplacedDijet35_Inclusive1PtrkShortSig5") continue;
+			if (HLT_Names[i].find("L1SingleLLPJet") != string::npos &&
+			    HLT_Names[i] != "HLT_L1SingleLLPJet" &&
+			    i < (int)HLT_Decision->size() && HLT_Decision->at(i))
+				other_llpjet_hlt_jet = true;
 		}
+		if (hlt35_jet && !other_llpjet_hlt_jet) {
+			TRandom3 hlt_rng_jet(lumiNum * 1000033u + (UInt_t)eventNum);
+			hlt_prescale_weight_jet = (hlt_rng_jet.Uniform() < 0.7233) ? 1.0f : 0.0f;
+		}
+	}
+	if (!isData && currentEra_ == "2023postBPix") {
+		bool hlt35_jet = GetTriggerDecision("HLT_HT200_L1SingleLLPJet_DisplacedDijet35_Inclusive1PtrkShortSig5");
+		bool other_llpjet_hlt_jet = false;
+		for (int i = 0; i < (int)HLT_Names.size(); i++) {
+			if (HLT_Names[i] == "HLT_HT200_L1SingleLLPJet_DisplacedDijet35_Inclusive1PtrkShortSig5") continue;
+			if (HLT_Names[i].find("L1SingleLLPJet") != string::npos &&
+			    HLT_Names[i] != "HLT_L1SingleLLPJet" &&
+			    i < (int)HLT_Decision->size() && HLT_Decision->at(i))
+				other_llpjet_hlt_jet = true;
+		}
+		if (hlt35_jet && !other_llpjet_hlt_jet)
+			hlt_prescale_weight_jet = 0.0f;
 	}
 	jet_tree_output_vars_float["HLT_prescale_weight"] = hlt_prescale_weight_jet;
 

--- a/DisplacedHcalJetAnalyzer/src/WeightsHelper.cxx
+++ b/DisplacedHcalJetAnalyzer/src/WeightsHelper.cxx
@@ -6,16 +6,15 @@ void DisplacedHcalJetAnalyzer::SetWeight(string infiletag){
 	// determine weights for MC to add as a new branch to the minituples
     cout << "Getting samples weight" << endl;
 
-    bool data = false, signal = false;
-    cout << infiletag << endl;
-    if (infiletag.find("CTau") != string::npos ) signal = true;
-    if (infiletag.find("PromptReco") != string::npos ) data = true;
-
-    //cout << data << " = is data flag" << endl;
-    //cout << signal << " = is signal flag" << endl;
+    // read isData and era from the ntuple itself — reliable regardless of file naming
+    if (fChain) { b_isData->GetEntry(0); b_era->GetEntry(0); currentEra_ = *era; }
+    bool data = isData;
+    bool signal = infiletag.find("CTau") != string::npos;
+    cout << infiletag << " (isData=" << data << ")" << endl;
 
 	if( data ){
         weight = 1;
+        lumi_frac = 1;
         cout << "weight --> " << weight << endl;
         return;
 	}
@@ -24,8 +23,12 @@ void DisplacedHcalJetAnalyzer::SetWeight(string infiletag){
     // lumi in fb^-1
     double lumi = 1;
     // when process multiple years need to handle each lumi (CMS recorded lumi)
-    double lumi_2022 = 34.76,  lumi_2023 = 28.28; // fb^-1, from brilcalc tool on 1 June 2026, agrees with HLT trigger prescale settings
+    double lumi_2022 = 34.6644,  lumi_2023 = 27.6410; // fb^-1, from brilcalc tool on 6 June 2026, agrees with HLT trigger prescale settings
     // double lumi_2022 = 38.01,  lumi_2023 = 30.12; // fb^-1, https://twiki.cern.ch/twiki/bin/view/CMSPublic/LumiPublicResults#2023_proton_proton_collisions_at
+    double lumi_preEE = 7.9895; // preEE
+    double lumi_postEE = 26.6749; // postEE only
+    double lumi_preBPix = 17.9642; // preBPix only
+    double lumi_postBPix = 9.67674; // postBPix
     // deal with luminosity from different MC samples, if year depedent. Now everything is 2023
     lumi = lumi_2022 + lumi_2023;
 
@@ -42,14 +45,22 @@ void DisplacedHcalJetAnalyzer::SetWeight(string infiletag){
     } else {
         // would also deal with MC background processes here, like W+jets or Z->mu, to get BRxSigma
         weight = 1.0;
+        lumi_frac = 1.0;
     }
 	
     // Weight for each event
 	weight = BRxSigma*lumi/NEvents_produced; // weight = lumi * xsec (=# higgs) * BR (=# LLP)
     // if NEvents_produced == 1, then the filetag was not found. Instead of setting a too high weight, set event weight to 1
     if ( !data && infiletag.find("CTau") != string::npos && NEvents_produced == 1) weight = 1;
-	lumi_samplefrac  = lumiNum/(lumi_2022+lumi_2023);
-	cout<<"  weight   --> "<<weight<<" (event-by-event weight components included later)"<<endl;
+	// lumi_samplefrac  = lumiNum/lumi;
+    
+    if      (!data && currentEra_ == "2022preEE")    lumi_frac = lumi_preEE/lumi;
+    else if (!data && currentEra_ == "2022postEE")   lumi_frac = (lumi_postEE + lumi_preBPix)/lumi;
+    // else if (!data && currentEra_ == "2023preBPix")  lumi_frac = lumi_preBPix/lumi;
+    else if (!data && currentEra_ == "2023postBPix") lumi_frac = lumi_postBPix/lumi;
+	
+    cout<<"  weight   --> "<<weight<<" (event-by-event weight components included later)"<<endl;
+    cout<<"  lumi_frac   --> "<<lumi_frac<<endl;
 
 	cout<<endl;
 

--- a/MiniTuplePlotter/Gillian/MiniTuplePlotter_DNN.C
+++ b/MiniTuplePlotter/Gillian/MiniTuplePlotter_DNN.C
@@ -26,6 +26,7 @@ void MiniTuplePlotter_DNN(){
 	string path_v5 = "/eos/cms/store/group/phys_exotica/HCAL_LLP/MiniTuples/v5.3/minituple_"; // used to be from v5.3 (v4 AN)
 	vector<string> filetags_all_signal_v5 = { "HToSSTo4B_125_50_CTau3000_scores", "HToSSTo4B_250_120_CTau10000_scores", "HToSSTo4B_350_160_CTau10000_scores", "HToSSTo4B_350_80_CTau500_scores"};
 	vector<string> filetags_all_data_v5 = { "data_2023Cv1_scores", "data_2023Cv2_scores", "data_2023Cv3_scores", "data_2023Cv4_scores", "data_2023Dv1_scores", "data_2023Dv2_scores"};
+	// vector<string> filetags_all_data_v5 = { "data_2023Cv4_scores"};
 	vector<string> filetags_all_data_v5_2022 = { "data_2022Dv1_scores", "data_2022Ev1_scores", "data_2022Fv1_scores", "data_2022Gv1_scores"};
 
 	// ----- Example 1 -----//
@@ -35,7 +36,8 @@ void MiniTuplePlotter_DNN(){
 	bool study3 = false;
 	bool study4 = false;
 	bool study5 = false; // for v3, v5 AN plots
-	bool study6 = true; // DNN input variable distributions per era
+	bool study6 = false; // DNN input variable distributions per era
+	bool study7 = true; // Depth energy fractions vs jet pT bins, per era
  	
 	cout<<endl;
 	cout<<" ---------- Study 1: Overlay LLP MC and data ---------- "<<endl;
@@ -360,6 +362,9 @@ void MiniTuplePlotter_DNN(){
 		DNNinputs_data_23.SetCuts("jet0_InclTagCand == 1");
 		DNNinputs_data_23.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
 		DNNinputs_data_23.SetLegendNames({"Cv1", "Cv2", "Cv3", "Cv4", "Dv1", "Dv2"});
+		// DNNinputs_data_23.SetSelectiveCuts("Cv4", "run < 368822");
+		// DNNinputs_data_23.SetLegendNames({"Cv4, pre alignment", "Cv4, post alignment"});
+		// DNNinputs_data_23.SetComparisonCuts({"run < 368822", "run >= 368822"});
 		DNNinputs_data_23.NBins           = 50;
 		DNNinputs_data_23.use_weight      = true;
 		DNNinputs_data_23.Plot();
@@ -390,5 +395,73 @@ void MiniTuplePlotter_DNN(){
 		DNNinputs_data_22.SetOutputFileTag("DNNinputs_data_2022_depth");
 		DNNinputs_data_22.SetCuts("jet0_DepthTagCand == 1");
 		DNNinputs_data_22.Plot();
+	}
+
+	// Study 7: Depth energy fractions vs jet pT bins, per era
+	// Run: mkdir -p Plots/DepthFracsVsPt  before executing
+	// -------------------------------------------------------------- //
+	cout<<endl;
+	cout<<" ---------- Study 7: Depth energy fractions vs jet pT bins, per era ---------- "<<endl;
+	cout<<endl;
+	if (study7) {
+		vector<PlotParams> depth_frac_vars = {
+			P_jet0_EnergyFrac_Depth1, P_jet0_EnergyFrac_Depth2, P_jet0_EnergyFrac_Depth3, P_jet0_EnergyFrac_Depth4
+		};
+		vector<TCut> pT_cuts = {
+			"jet0_Pt >= 60 && jet0_Pt < 70",
+			"jet0_Pt >= 70 && jet0_Pt < 80",
+			"jet0_Pt >= 80 && jet0_Pt < 90",
+			"jet0_Pt >= 90 && jet0_Pt < 100",
+			"jet0_Pt >= 100"
+		};
+		vector<string> pT_legend = {"p_{T} 60-70 GeV", "p_{T} 70-80 GeV", "p_{T} 80-90 GeV", "p_{T} 90-100 GeV", "p_{T} 100+ GeV"};
+
+		// 2023Cv3
+		class MiniTuplePlotter depthfracs_Cv3( {"data_2023Cv3_scores"}, path_v5 );
+		depthfracs_Cv3.SetTreeName( "NoSel" );
+		depthfracs_Cv3.SetPlots( depth_frac_vars );
+		depthfracs_Cv3.SetOutputFileTag("DepthFracs_pTbins_2023Cv3");
+		depthfracs_Cv3.SetOutputDirectory("DepthFracsVsPt");
+		depthfracs_Cv3.plot_norm       = true;
+		depthfracs_Cv3.plot_log        = true;
+		depthfracs_Cv3.SetCuts("jet0_DepthTagCand == 1");
+		depthfracs_Cv3.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
+		depthfracs_Cv3.SetLegendNames( pT_legend );
+		depthfracs_Cv3.SetComparisonCuts( pT_cuts );
+		depthfracs_Cv3.NBins           = 50;
+		depthfracs_Cv3.use_weight      = true;
+		depthfracs_Cv3.Plot();
+
+		// 2023Cv4
+		class MiniTuplePlotter depthfracs_Cv4( {"data_2023Cv4_scores"}, path_v5 );
+		depthfracs_Cv4.SetTreeName( "NoSel" );
+		depthfracs_Cv4.SetPlots( depth_frac_vars );
+		depthfracs_Cv4.SetOutputFileTag("DepthFracs_pTbins_2023Cv4");
+		depthfracs_Cv4.SetOutputDirectory("DepthFracsVsPt");
+		depthfracs_Cv4.plot_norm       = true;
+		depthfracs_Cv4.plot_log        = true;
+		depthfracs_Cv4.SetCuts("jet0_DepthTagCand == 1");
+		depthfracs_Cv4.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
+		depthfracs_Cv4.SetLegendNames( pT_legend );
+		depthfracs_Cv4.SetComparisonCuts( pT_cuts );
+		depthfracs_Cv4.NBins           = 50;
+		depthfracs_Cv4.use_weight      = true;
+		depthfracs_Cv4.Plot();
+
+		// 2023Dv1
+		class MiniTuplePlotter depthfracs_Dv1( {"data_2023Dv1_scores"}, path_v5 );
+		depthfracs_Dv1.SetTreeName( "NoSel" );
+		depthfracs_Dv1.SetPlots( depth_frac_vars );
+		depthfracs_Dv1.SetOutputFileTag("DepthFracs_pTbins_2023Dv1");
+		depthfracs_Dv1.SetOutputDirectory("DepthFracsVsPt");
+		depthfracs_Dv1.plot_norm       = true;
+		depthfracs_Dv1.plot_log        = true;
+		depthfracs_Dv1.SetCuts("jet0_DepthTagCand == 1");
+		depthfracs_Dv1.SetLegendPosition( 0.6, 0.7, 0.88, 0.88 );
+		depthfracs_Dv1.SetLegendNames( pT_legend );
+		depthfracs_Dv1.SetComparisonCuts( pT_cuts );
+		depthfracs_Dv1.NBins           = 50;
+		depthfracs_Dv1.use_weight      = true;
+		depthfracs_Dv1.Plot();
 	}
 }

--- a/Run/Condor/condor_executable.sh
+++ b/Run/Condor/condor_executable.sh
@@ -61,7 +61,7 @@ pip3 install awkward
 pip3 install zipp
 
 echo "Evaluating DNN..."
-python3 Evaluate/ScoresToEventBased.py -f  minituple_$filetag.root -t NoSel -d Evaluate/depth_model_v6.keras -i Evaluate/inclusive_model_v6.keras -c Evaluate/norm_constants_v4.csv -m filewrite
+python3 Evaluate/ScoresToEventBased_iterate.py -f  minituple_$filetag.root -t NoSel -d Evaluate/depth_model_v5.keras -i Evaluate/inclusive_model_v5.keras -c Evaluate/norm_constants_v4.csv -m filewrite
 
 echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')\n"
 

--- a/Run/Condor/submit_all.sh
+++ b/Run/Condor/submit_all.sh
@@ -1,19 +1,14 @@
 #!/bin/bash
 
 # Update these!
-output_basedir=/eos/home-g/gkopp/LLP_Analysis/MiniTuples/v5.4/
+output_basedir=/eos/home-g/gkopp/LLP_Analysis/MiniTuples/v5.5/
 proxypath=~/private/x509up_u101898
 
-#output_basedir=/eos/home-g/gkopp/LLP_Analysis/MiniTuples/v5.1/
-#proxypath=~/private/x509up_u101898
-
-systematic=Nominal
-
-for input_file in ../Ntuples_v5/InputFiles_HToSSTo4B_MH*L1triggers_v5.txt; do
+for input_file in ../Ntuples_v5/InputFiles_DisplacedJet_Run2023*_v5.txt; do
 
   filetag=`basename $input_file .txt | sed 's/^InputFiles_//'`
   echo "Submitting job for: $input_files"
-  echo "python3 condor_run.py -i $input_file -o $output_basedir$filetag -p  ~/private/x509up_u101440  -f $filetag$systematic -u $systematic"
-  #python3 condor_run.py -i $input_file -o $output_basedir$filetag -p  ~/private/x509up_u101440  -f $filetag$systematic -u $systematic
+  echo "python3 condor_run.py -i $input_file -o $output_basedir$filetag -p $proxypath  -f $filetag"
+  python3 condor_run.py -i $input_file -o $output_basedir$filetag -p $proxypath  -f $filetag
 
 done

--- a/Run/Condor/submit_all.sh
+++ b/Run/Condor/submit_all.sh
@@ -3,12 +3,14 @@
 # Update these!
 output_basedir=/eos/home-g/gkopp/LLP_Analysis/MiniTuples/v5.5/
 proxypath=~/private/x509up_u101898
+systematic=Nominal
 
-for input_file in ../Ntuples_v5/InputFiles_DisplacedJet_Run2023*_v5.txt; do
+#for input_file in ../Ntuples_v5/InputFiles_DisplacedJet_Run2023*_v5.txt; do
+for input_file in ../Ntuples_v5/Central/RAW_HToSSTo4B_MH125_MS12_CTau9000_Premix_2022preEE_batch1_L1triggers_v5.txt; do
 
-  filetag=`basename $input_file .txt | sed 's/^InputFiles_//'`
+  filetag=`basename $input_file .txt | sed -E 's/^(InputFiles_|RAW_)//'`
   echo "Submitting job for: $input_files"
-  echo "python3 condor_run.py -i $input_file -o $output_basedir$filetag -p $proxypath  -f $filetag"
-  python3 condor_run.py -i $input_file -o $output_basedir$filetag -p $proxypath  -f $filetag
+  echo "python3 condor_run.py -i $input_file -o $output_basedir$filetag -p $proxypath  -f $filetag$systematic -u $systematic"
+  python3 condor_run.py -i $input_file -o $output_basedir$filetag -p $proxypath  -f $filetag$systematic -u $systematic
 
 done


### PR DESCRIPTION
- HLT prescales to handle dijet 35 that was disabled in the beginning of 2023C. This combines postEE and preBPix eras and emulates the trigger prescale by disabling the trigger 27.67% of this era. It is fully disabled for postBPix and enabled for preEE
- era_category 1, 2, 3 is added for preEE, postEE + preBPix, and postBPix for use in the DNN training
- lumi is added for each era and lumi_frac is reported, to be multiplied with weight from the total lumi
